### PR TITLE
Fixing Sort expression Issue

### DIFF
--- a/Cql/CodeGeneration.NET/ExpressionConverter.cs
+++ b/Cql/CodeGeneration.NET/ExpressionConverter.cs
@@ -230,7 +230,6 @@ namespace Hl7.Cql.CodeGeneration.NET
             return sb.ToString();
         }
 
-
         private string convertArguments(int indent, IEnumerable<Expression> paramList)
         {
             var sb = new StringBuilder();
@@ -596,7 +595,6 @@ namespace Hl7.Cql.CodeGeneration.NET
                 return binaryString;
             }
         }
-
         private string convertListInitExpression(int indent, string leadingIndentString, ListInitExpression listInit)
         {
             var sb = new StringBuilder();

--- a/Cql/CodeGeneration.NET/ExpressionConverter.cs
+++ b/Cql/CodeGeneration.NET/ExpressionConverter.cs
@@ -53,6 +53,7 @@ namespace Hl7.Cql.CodeGeneration.NET
                 CaseWhenThenExpression cwt => convertCaseWhenThenExpression(indent, cwt),
                 FunctionCallExpression fce => convertFunctionCallExpression(indent, leadingIndentString, fce),
                 DefinitionCallExpression dce => convertDefinitionCallExpression(indent, leadingIndentString, dce),
+                ListInitExpression lie => convertListInitExpression(indent, leadingIndentString, lie),
                 ElmAsExpression ea => ConvertExpression(indent, ea.Reduce(), leadingIndent),
                 _ => throw new NotSupportedException($"Don't know how to convert an expression of type {expression.GetType()} into C#."),
             };
@@ -228,6 +229,7 @@ namespace Hl7.Cql.CodeGeneration.NET
             sb.Append(convertArguments(indent, paramList));
             return sb.ToString();
         }
+
 
         private string convertArguments(int indent, IEnumerable<Expression> paramList)
         {
@@ -593,6 +595,26 @@ namespace Hl7.Cql.CodeGeneration.NET
                 var binaryString = $"{leadingIndentString}({leftCode} {@operator} {rightCode})";
                 return binaryString;
             }
+        }
+
+        private string convertListInitExpression(int indent, string leadingIndentString, ListInitExpression listInit)
+        {
+            var sb = new StringBuilder();
+            sb.Append(leadingIndentString);
+
+            var listType = PrettyTypeName(listInit.Type);
+            sb.AppendLine(CultureInfo.InvariantCulture, $"new {listType}");
+            sb.AppendLine(IndentString(indent) + "{");
+
+            foreach (var initializer in listInit.Initializers)
+            {
+                var arguments = initializer.Arguments.Select(arg => ConvertExpression(indent + 1, arg, false));
+                var argumentString = string.Join(", ", arguments);
+                sb.AppendLine(IndentString(indent + 1) + $"{{ {argumentString} }},");
+            }
+
+            sb.Append(IndentString(indent) + "}");
+            return sb.ToString();
         }
 
         private static string BinaryOperatorFor(ExpressionType nodeType) => nodeType switch

--- a/Cql/CodeGeneration.NET/ExpressionConverter.cs
+++ b/Cql/CodeGeneration.NET/ExpressionConverter.cs
@@ -53,7 +53,6 @@ namespace Hl7.Cql.CodeGeneration.NET
                 CaseWhenThenExpression cwt => convertCaseWhenThenExpression(indent, cwt),
                 FunctionCallExpression fce => convertFunctionCallExpression(indent, leadingIndentString, fce),
                 DefinitionCallExpression dce => convertDefinitionCallExpression(indent, leadingIndentString, dce),
-                ListInitExpression lie => convertListInitExpression(indent, leadingIndentString, lie),
                 ElmAsExpression ea => ConvertExpression(indent, ea.Reduce(), leadingIndent),
                 _ => throw new NotSupportedException($"Don't know how to convert an expression of type {expression.GetType()} into C#."),
             };
@@ -595,26 +594,7 @@ namespace Hl7.Cql.CodeGeneration.NET
                 return binaryString;
             }
         }
-        private string convertListInitExpression(int indent, string leadingIndentString, ListInitExpression listInit)
-        {
-            var sb = new StringBuilder();
-            sb.Append(leadingIndentString);
-
-            var listType = PrettyTypeName(listInit.Type);
-            sb.AppendLine(CultureInfo.InvariantCulture, $"new {listType}");
-            sb.AppendLine(IndentString(indent) + "{");
-
-            foreach (var initializer in listInit.Initializers)
-            {
-                var arguments = initializer.Arguments.Select(arg => ConvertExpression(indent + 1, arg, false));
-                var argumentString = string.Join(", ", arguments);
-                sb.AppendLine(IndentString(indent + 1) + $"{{ {argumentString} }},");
-            }
-
-            sb.Append(IndentString(indent) + "}");
-            return sb.ToString();
-        }
-
+        
         private static string BinaryOperatorFor(ExpressionType nodeType) => nodeType switch
         {
             ExpressionType.Add => "+",

--- a/Cql/Cql.Abstractions/CqlOperator.cs
+++ b/Cql/Cql.Abstractions/CqlOperator.cs
@@ -168,7 +168,7 @@ namespace Hl7.Cql.Abstractions
         Where,
         Sort,
         SortBy,
-        SortByMultiple,
+        ThenBy,
         Single,
         MeetsAfter,
         MeetsBefore,

--- a/Cql/Cql.Abstractions/CqlOperator.cs
+++ b/Cql/Cql.Abstractions/CqlOperator.cs
@@ -168,6 +168,7 @@ namespace Hl7.Cql.Abstractions
         Where,
         Sort,
         SortBy,
+        SortByMultiple,
         Single,
         MeetsAfter,
         MeetsBefore,

--- a/Cql/Cql.Compiler/CqlOperatorsBinding.cs
+++ b/Cql/Cql.Compiler/CqlOperatorsBinding.cs
@@ -533,26 +533,7 @@ namespace Hl7.Cql.Compiler
 
                 var elementType = TypeResolver.GetListElementType(source.Type)
                     ?? throw new InvalidOperationException($"{source.Type} was expected to be a list type.");
-                #region Testing
-                //var sortByLambdas = new List<Expression>();
-                //var sortOrders = new List<Expression>();
-
-                //for (int i = 0; i < byArray.Expressions.Count; i++)
-                //{
-                //    if (byArray.Expressions[i] is LambdaExpression lambda &&
-                //        orderArray.Expressions[i] is ConstantExpression orderConstant &&
-                //        orderConstant.Type == typeof(ListSortDirection))
-                //    {
-                //        sortByLambdas.Add(lambda);
-                //        sortOrders.Add(orderConstant);
-                //    }
-                //    else
-                //    {
-                //        throw new ArgumentException("SortByMultiple expects 'sortByExpressions' to contain lambdas and 'sortDirections' to contain ListSortDirection constants.", nameof(sortByExpressions));
-                //    }
-                //}
-                #endregion 
-
+                
                 var method = OperatorsType
                     .GetMethod(nameof(ICqlOperators.ListSortByMultiple))!
                     .MakeGenericMethod(elementType);

--- a/Cql/Cql.Compiler/CqlOperatorsBinding.cs
+++ b/Cql/Cql.Compiler/CqlOperatorsBinding.cs
@@ -441,6 +441,8 @@ namespace Hl7.Cql.Compiler
                     return BindUnaryOperator(nameof(ICqlOperators.Descendents), operators, parameters[0]);
                 case CqlOperator.SortBy:
                     return SortBy(operators, parameters[0], parameters[1], parameters[2]);
+                case CqlOperator.SortByMultiple:
+                    return SortByMultiple(operators, parameters[0], parameters[1], parameters[2]);
                 case CqlOperator.Aggregate:
                     return Aggregate(operators, parameters[0], parameters[1], parameters[2]);
                 case CqlOperator.Implies:
@@ -518,6 +520,37 @@ namespace Hl7.Cql.Compiler
 
             }
             else throw new ArgumentException("SortBy expects 3 parameters: source, lambda, and SortOrder constant", nameof(by));
+        }
+
+        private Expression SortByMultiple(MemberExpression operators, Expression source, Expression bys, Expression orders)
+        {
+            if (bys is NewArrayExpression newArray && orders is NewArrayExpression orderArray)
+            {
+                var elementType = TypeResolver.GetListElementType(source.Type) ?? throw new InvalidOperationException($"{source.Type} was expected to be a list type.");
+                var sortMethods = new List<Expression>();
+
+                for (int i = 0; i < newArray.Expressions.Count; i++)
+                {
+                    if (newArray.Expressions[i] is LambdaExpression lambda && orderArray.Expressions[i] is ConstantExpression orderConstant && orderConstant.Type == typeof(ListSortDirection))
+                    {
+                        var method = OperatorsType
+                            .GetMethod(nameof(ICqlOperators.ListSortByMultiple))!
+                            .MakeGenericMethod(elementType);
+                        var call = Expression.Call(operators, method, source, lambda, orderConstant);
+                        sortMethods.Add(call);
+                    }
+                    else
+                    {
+                        throw new ArgumentException("SortByMultiple expects matching arrays of lambdas and SortOrder constants", nameof(bys));
+                    }
+                }
+
+                return sortMethods.Aggregate((current, next) => Expression.Call(next, current));
+            }
+            else
+            {
+                throw new ArgumentException("SortByMultiple expects arrays for both 'by' and 'order' parameters", nameof(bys));
+            }
         }
 
         private Expression InList(MemberExpression operators, Expression left, Expression right)

--- a/Cql/Cql.Compiler/CqlOperatorsBinding.cs
+++ b/Cql/Cql.Compiler/CqlOperatorsBinding.cs
@@ -524,32 +524,48 @@ namespace Hl7.Cql.Compiler
 
         private Expression SortByMultiple(MemberExpression operators, Expression source, Expression bys, Expression orders)
         {
-            if (bys is NewArrayExpression newArray && orders is NewArrayExpression orderArray)
+            if (bys is NewArrayExpression byArray && orders is NewArrayExpression orderArray)
             {
-                var elementType = TypeResolver.GetListElementType(source.Type) ?? throw new InvalidOperationException($"{source.Type} was expected to be a list type.");
-                var sortMethods = new List<Expression>();
-
-                for (int i = 0; i < newArray.Expressions.Count; i++)
+                if (byArray.Expressions.Count != orderArray.Expressions.Count)
                 {
-                    if (newArray.Expressions[i] is LambdaExpression lambda && orderArray.Expressions[i] is ConstantExpression orderConstant && orderConstant.Type == typeof(ListSortDirection))
+                    throw new ArgumentException("SortByMultiple expects matching arrays of 'bys' and 'orders'.", nameof(bys));
+                }
+
+                var elementType = TypeResolver.GetListElementType(source.Type)
+                    ?? throw new InvalidOperationException($"{source.Type} was expected to be a list type.");
+
+                var sortTuples = new List<Expression>();
+
+                for (int i = 0; i < byArray.Expressions.Count; i++)
+                {
+                    if (byArray.Expressions[i] is LambdaExpression lambda &&
+                        orderArray.Expressions[i] is ConstantExpression orderConstant &&
+                        orderConstant.Type == typeof(ListSortDirection))
                     {
-                        var method = OperatorsType
-                            .GetMethod(nameof(ICqlOperators.ListSortByMultiple))!
-                            .MakeGenericMethod(elementType);
-                        var call = Expression.Call(operators, method, source, lambda, orderConstant);
-                        sortMethods.Add(call);
+                        var tuple = Expression.New(
+                            typeof(ValueTuple<LambdaExpression, ListSortDirection>).GetConstructor(new[] { typeof(LambdaExpression), typeof(ListSortDirection) })!,
+                            lambda,
+                            orderConstant
+                        );
+                        sortTuples.Add(tuple);
                     }
                     else
                     {
-                        throw new ArgumentException("SortByMultiple expects matching arrays of lambdas and SortOrder constants", nameof(bys));
+                        throw new ArgumentException("SortByMultiple expects 'bys' to contain lambdas and 'orders' to contain ListSortDirection constants.", nameof(bys));
                     }
                 }
 
-                return sortMethods.Aggregate((current, next) => Expression.Call(next, current));
+                var tupleArray = Expression.NewArrayInit(typeof(ValueTuple<LambdaExpression, ListSortDirection>), sortTuples);
+
+                var method = OperatorsType
+                    .GetMethod(nameof(ICqlOperators.ListSortByMultiple))!
+                    .MakeGenericMethod(elementType);
+
+                return Expression.Call(operators, method, source, tupleArray);
             }
             else
             {
-                throw new ArgumentException("SortByMultiple expects arrays for both 'by' and 'order' parameters", nameof(bys));
+                throw new ArgumentException("SortByMultiple expects arrays for both 'bys' and 'orders' parameters.", nameof(bys));
             }
         }
 

--- a/Cql/Cql.Compiler/CqlOperatorsBinding.cs
+++ b/Cql/Cql.Compiler/CqlOperatorsBinding.cs
@@ -542,9 +542,21 @@ namespace Hl7.Cql.Compiler
                         orderArray.Expressions[i] is ConstantExpression orderConstant &&
                         orderConstant.Type == typeof(ListSortDirection))
                     {
+                        // Create a new parameter of type object
+                        var newParameter = Expression.Parameter(typeof(object), lambda.Parameters[0].Name);
+
+                        // Replace the original parameter with the new parameter in the lambda body
+                        var replacedBody = ReplaceParameter(lambda.Body, lambda.Parameters[0], Expression.Convert(newParameter, lambda.Parameters[0].Type));
+
+                        // Create a new lambda with the updated parameter and body
+                        var convertedLambda = Expression.Lambda(
+                            typeof(Func<object, object>),
+                            Expression.Convert(replacedBody, typeof(object)),
+                            newParameter);
+
                         var tuple = Expression.New(
-                            typeof(ValueTuple<LambdaExpression, ListSortDirection>).GetConstructor(new[] { typeof(LambdaExpression), typeof(ListSortDirection) })!,
-                            lambda,
+                            typeof(ValueTuple<Func<object, object>, ListSortDirection>).GetConstructor(new[] { typeof(Func<object, object>), typeof(ListSortDirection) })!,
+                            convertedLambda,
                             orderConstant
                         );
                         sortTuples.Add(tuple);
@@ -555,17 +567,40 @@ namespace Hl7.Cql.Compiler
                     }
                 }
 
-                var tupleArray = Expression.NewArrayInit(typeof(ValueTuple<LambdaExpression, ListSortDirection>), sortTuples);
+                var tupleArray = Expression.NewArrayInit(typeof(ValueTuple<Func<object, object>, ListSortDirection>), sortTuples);
 
                 var method = OperatorsType
                     .GetMethod(nameof(ICqlOperators.ListSortByMultiple))!
                     .MakeGenericMethod(elementType);
 
-                return Expression.Call(operators, method, source, tupleArray);
+                var call=  Expression.Call(operators, method, source, tupleArray);
+                return call;
             }
             else
             {
                 throw new ArgumentException("SortByMultiple expects arrays for both 'bys' and 'orders' parameters.", nameof(bys));
+            }
+        }
+
+        private Expression ReplaceParameter(Expression body, ParameterExpression target, Expression replacement)
+        {
+            return new InlineParameterReplacer(target, replacement).Visit(body);
+        }
+
+        private class InlineParameterReplacer : ExpressionVisitor
+        {
+            private readonly ParameterExpression _target;
+            private readonly Expression _replacement;
+
+            public InlineParameterReplacer(ParameterExpression target, Expression replacement)
+            {
+                _target = target;
+                _replacement = replacement;
+            }
+
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                return node == _target ? _replacement : base.VisitParameter(node);
             }
         }
 

--- a/Cql/Cql.Compiler/CqlOperatorsBinding.cs
+++ b/Cql/Cql.Compiler/CqlOperatorsBinding.cs
@@ -441,8 +441,8 @@ namespace Hl7.Cql.Compiler
                     return BindUnaryOperator(nameof(ICqlOperators.Descendents), operators, parameters[0]);
                 case CqlOperator.SortBy:
                     return SortBy(operators, parameters[0], parameters[1], parameters[2]);
-                case CqlOperator.SortByMultiple:
-                    return SortByMultiple(operators, parameters[0], parameters[1], parameters[2]);
+                case CqlOperator.ThenBy:
+                    return ThenBy(operators, parameters[0], parameters[1], parameters[2]);
                 case CqlOperator.Aggregate:
                     return Aggregate(operators, parameters[0], parameters[1], parameters[2]);
                 case CqlOperator.Implies:
@@ -522,30 +522,19 @@ namespace Hl7.Cql.Compiler
             else throw new ArgumentException("SortBy expects 3 parameters: source, lambda, and SortOrder constant", nameof(by));
         }
 
-        private Expression SortByMultiple(MemberExpression operators, Expression source, Expression sortExpressions, Expression sortDirections)
+        private Expression ThenBy(MemberExpression operators, Expression source, Expression by, Expression order)
         {
-            if (sortExpressions is ListInitExpression byList && sortDirections is ListInitExpression orderList)
+            if (by is LambdaExpression lambda && order is ConstantExpression orderConstant && orderConstant.Type == typeof(ListSortDirection))
             {
-                if (byList.Initializers.Count != orderList.Initializers.Count)
-                {
-                    throw new ArgumentException("SortByMultiple expects matching arrays of 'sortByExpressions' and 'sortDirections'.", nameof(sortExpressions));
-                }
-
-                var elementType = TypeResolver.GetListElementType(source.Type)
-                    ?? throw new InvalidOperationException($"{source.Type} was expected to be a list type.");
-                
+                var elementType = TypeResolver.GetListElementType(source.Type) ?? throw new InvalidOperationException($"{source.Type} was expected to be a list type.");
                 var method = OperatorsType
-                    .GetMethod(nameof(ICqlOperators.ListSortByMultiple))!
+                    .GetMethod(nameof(ICqlOperators.ListThenBy))!
                     .MakeGenericMethod(elementType);
-
-                var call = Expression.Call(operators, method, source, sortExpressions, sortDirections);
+                var call = Expression.Call(operators, method, source, lambda, orderConstant);
                 return call;
             }
-            else
-            {
-                throw new ArgumentException("SortByMultiple expects List for both 'sortByExpressions' and 'sortDirections' parameters.", nameof(sortExpressions));
-            }
-        }        
+            else throw new ArgumentException("ThenBy expects 3 parameters: source, lambda, and SortOrder constant", nameof(by));
+        }
 
         private Expression InList(MemberExpression operators, Expression left, Expression right)
         {

--- a/Cql/Cql.Compiler/CqlOperatorsBinding.cs
+++ b/Cql/Cql.Compiler/CqlOperatorsBinding.cs
@@ -522,87 +522,49 @@ namespace Hl7.Cql.Compiler
             else throw new ArgumentException("SortBy expects 3 parameters: source, lambda, and SortOrder constant", nameof(by));
         }
 
-        private Expression SortByMultiple(MemberExpression operators, Expression source, Expression bys, Expression orders)
+        private Expression SortByMultiple(MemberExpression operators, Expression source, Expression sortExpressions, Expression sortDirections)
         {
-            if (bys is NewArrayExpression byArray && orders is NewArrayExpression orderArray)
+            if (sortExpressions is ListInitExpression byList && sortDirections is ListInitExpression orderList)
             {
-                if (byArray.Expressions.Count != orderArray.Expressions.Count)
+                if (byList.Initializers.Count != orderList.Initializers.Count)
                 {
-                    throw new ArgumentException("SortByMultiple expects matching arrays of 'bys' and 'orders'.", nameof(bys));
+                    throw new ArgumentException("SortByMultiple expects matching arrays of 'sortByExpressions' and 'sortDirections'.", nameof(sortExpressions));
                 }
 
                 var elementType = TypeResolver.GetListElementType(source.Type)
                     ?? throw new InvalidOperationException($"{source.Type} was expected to be a list type.");
+                #region Testing
+                //var sortByLambdas = new List<Expression>();
+                //var sortOrders = new List<Expression>();
 
-                var sortTuples = new List<Expression>();
-
-                for (int i = 0; i < byArray.Expressions.Count; i++)
-                {
-                    if (byArray.Expressions[i] is LambdaExpression lambda &&
-                        orderArray.Expressions[i] is ConstantExpression orderConstant &&
-                        orderConstant.Type == typeof(ListSortDirection))
-                    {
-                        // Create a new parameter of type object
-                        var newParameter = Expression.Parameter(typeof(object), lambda.Parameters[0].Name);
-
-                        // Replace the original parameter with the new parameter in the lambda body
-                        var replacedBody = ReplaceParameter(lambda.Body, lambda.Parameters[0], Expression.Convert(newParameter, lambda.Parameters[0].Type));
-
-                        // Create a new lambda with the updated parameter and body
-                        var convertedLambda = Expression.Lambda(
-                            typeof(Func<object, object>),
-                            Expression.Convert(replacedBody, typeof(object)),
-                            newParameter);
-
-                        var tuple = Expression.New(
-                            typeof(ValueTuple<Func<object, object>, ListSortDirection>).GetConstructor(new[] { typeof(Func<object, object>), typeof(ListSortDirection) })!,
-                            convertedLambda,
-                            orderConstant
-                        );
-                        sortTuples.Add(tuple);
-                    }
-                    else
-                    {
-                        throw new ArgumentException("SortByMultiple expects 'bys' to contain lambdas and 'orders' to contain ListSortDirection constants.", nameof(bys));
-                    }
-                }
-
-                var tupleArray = Expression.NewArrayInit(typeof(ValueTuple<Func<object, object>, ListSortDirection>), sortTuples);
+                //for (int i = 0; i < byArray.Expressions.Count; i++)
+                //{
+                //    if (byArray.Expressions[i] is LambdaExpression lambda &&
+                //        orderArray.Expressions[i] is ConstantExpression orderConstant &&
+                //        orderConstant.Type == typeof(ListSortDirection))
+                //    {
+                //        sortByLambdas.Add(lambda);
+                //        sortOrders.Add(orderConstant);
+                //    }
+                //    else
+                //    {
+                //        throw new ArgumentException("SortByMultiple expects 'sortByExpressions' to contain lambdas and 'sortDirections' to contain ListSortDirection constants.", nameof(sortByExpressions));
+                //    }
+                //}
+                #endregion 
 
                 var method = OperatorsType
                     .GetMethod(nameof(ICqlOperators.ListSortByMultiple))!
                     .MakeGenericMethod(elementType);
 
-                var call=  Expression.Call(operators, method, source, tupleArray);
+                var call = Expression.Call(operators, method, source, sortExpressions, sortDirections);
                 return call;
             }
             else
             {
-                throw new ArgumentException("SortByMultiple expects arrays for both 'bys' and 'orders' parameters.", nameof(bys));
+                throw new ArgumentException("SortByMultiple expects List for both 'sortByExpressions' and 'sortDirections' parameters.", nameof(sortExpressions));
             }
-        }
-
-        private Expression ReplaceParameter(Expression body, ParameterExpression target, Expression replacement)
-        {
-            return new InlineParameterReplacer(target, replacement).Visit(body);
-        }
-
-        private class InlineParameterReplacer : ExpressionVisitor
-        {
-            private readonly ParameterExpression _target;
-            private readonly Expression _replacement;
-
-            public InlineParameterReplacer(ParameterExpression target, Expression replacement)
-            {
-                _target = target;
-                _replacement = replacement;
-            }
-
-            protected override Expression VisitParameter(ParameterExpression node)
-            {
-                return node == _target ? _replacement : base.VisitParameter(node);
-            }
-        }
+        }        
 
         private Expression InList(MemberExpression operators, Expression left, Expression right)
         {

--- a/Cql/Cql.Compiler/ExpressionBuilder.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.cs
@@ -1200,71 +1200,66 @@ namespace Hl7.Cql.Compiler
             Type elementType = TypeResolver.GetListElementType(source.Type, @throw: true)!;
             var parameterName = "@this";
 
-            // Create a list to hold tuples of (keySelector, direction)  
-            var sortInstructions = new List<(Expression sortExpression, ListSortDirection direction)>();
-
-            foreach (var by in query.sort.by)
+            // Local function to build the sort key selector lambda
+            Expression BuildSortKeySelector(SortByItem byItem)
             {
-                ListSortDirection order = ExtensionMethods.ListSortOrder(by.direction);
-                Expression sortKeySelector;
-
-                if (by is ByExpression byExpression)
+                var sortMemberParameter = Expression.Parameter(elementType, parameterName);
+                if (byItem is ByExpression byExpression)
                 {
-                    var sortMemberParameter = Expression.Parameter(elementType, parameterName);
                     var subContext = ctx.WithImpliedAlias(parameterName!, sortMemberParameter, byExpression.expression);
                     var sortMemberExpression = TranslateExpression(byExpression.expression, subContext);
                     var lambdaBody = Expression.Convert(sortMemberExpression, typeof(object));
-                    sortKeySelector = Expression.Lambda(lambdaBody, sortMemberParameter);
+                    return Expression.Lambda(lambdaBody, sortMemberParameter);
                 }
-                else if (by is ByColumn byColumn)
+                else if (byItem is ByColumn byColumn)
                 {
-                    var sortMemberParameter = Expression.Parameter(elementType, parameterName);
                     var pathMemberType = TypeManager.TypeFor(byColumn, ctx);
                     if (pathMemberType == null)
                     {
-                        var msg = $"Type specifier {by.resultTypeName} at {by.locator ?? "unknown"} could not be resolved.";
+                        var msg = $"Type specifier {byItem.resultTypeName} at {byItem.locator ?? "unknown"} could not be resolved.";
                         ctx.LogError(msg);
                         throw new InvalidOperationException(msg);
                     }
                     var pathExpression = PropertyHelper(sortMemberParameter, byColumn.path, pathMemberType!, ctx);
                     var lambdaBody = Expression.Convert(pathExpression, typeof(object));
-                    sortKeySelector = Expression.Lambda(lambdaBody, sortMemberParameter);
+                    return Expression.Lambda(lambdaBody, sortMemberParameter);
+                }
+                else
+                {
+                    return null!;
+                }
+            }
+
+            Expression orderedList = source;
+            for (int i = 0; i < query.sort.by.Length; i++)
+            {
+                var byItem = query.sort.by[i];
+                ListSortDirection order = ExtensionMethods.ListSortOrder(byItem.direction);
+
+                var keySelector = BuildSortKeySelector(byItem);
+
+                if (keySelector != null)
+                {
+                    var op = (i == 0) ? CqlOperator.SortBy : CqlOperator.ThenBy;
+                    orderedList = OperatorBinding.Bind(
+                        op,
+                        ctx.RuntimeContextParameter,
+                        orderedList,
+                        keySelector,
+                        Expression.Constant(order, typeof(ListSortDirection))
+                    );
                 }
                 else
                 {
                     // Simple sort without a key selector  
-                    return OperatorBinding.Bind(CqlOperator.Sort, ctx.RuntimeContextParameter,
-                        source, Expression.Constant(order, typeof(ListSortDirection)));
+                    orderedList = OperatorBinding.Bind(CqlOperator.Sort, ctx.RuntimeContextParameter,
+                        orderedList, Expression.Constant(order, typeof(ListSortDirection)));
                 }
-
-                sortInstructions.Add((sortKeySelector, order));
             }
-
-            // If we have just one sort expression, use the simple SortBy  
-            if (sortInstructions.Count == 1)
-            {
-                return OperatorBinding.Bind(
-                    CqlOperator.SortBy,
-                    ctx.RuntimeContextParameter,
-                    source,
-                    sortInstructions[0].sortExpression,
-                    Expression.Constant(sortInstructions[0].direction, typeof(ListSortDirection))
-                );
-            }
-
-            // For multiple sort expressions, use the SortByMultiple operator  
-            var keySelectorList = Expression.ListInit(
-               Expression.New(typeof(List<>).MakeGenericType(typeof(Func<,>).MakeGenericType(elementType, typeof(object)))),
-               sortInstructions.Select(se => se.sortExpression)
-            );
-
-            var directionsList = Expression.ListInit(
-               Expression.New(typeof(List<ListSortDirection>)),
-               sortInstructions.Select(se => Expression.Constant(se.direction, typeof(ListSortDirection)))
-            );
-
-            return OperatorBinding.Bind(CqlOperator.SortByMultiple, ctx.RuntimeContextParameter,
-                source, keySelectorList, directionsList);
+            // Convert the ordered result to a IEnumerable
+            var ienumerableType = typeof(IEnumerable<>).MakeGenericType(elementType);
+            var asEnumerable = Expression.TypeAs(orderedList, ienumerableType);
+            return asEnumerable;
         }
 
         protected Expression MultiSourceQuery(Query query, ExpressionBuilderContext ctx)

--- a/Cql/Cql.Compiler/ExpressionBuilder.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.cs
@@ -1182,51 +1182,7 @@ namespace Hl7.Cql.Compiler
             //[System.Xml.Serialization.XmlIncludeAttribute(typeof(ByExpression))]
             //[System.Xml.Serialization.XmlIncludeAttribute(typeof(ByColumn))]
             //[System.Xml.Serialization.XmlIncludeAttribute(typeof(ByDirection))]
-            if (query.sort != null && query.sort.by != null && query.sort.by.Length > 0)
-            {
-                foreach (var by in query.sort.by)
-                {
-                    ListSortDirection order = ExtensionMethods.ListSortOrder(by.direction);
-                    if (by is ByExpression byExpression)
-                    {
-                        var parameterName = "@this";
-                        var returnElementType = TypeResolver.GetListElementType(@return.Type, true)!;
-                        var sortMemberParameter = Expression.Parameter(returnElementType, parameterName);
-                        var subContext = ctx.WithImpliedAlias(parameterName!, sortMemberParameter, byExpression.expression);
-                        var sortMemberExpression = TranslateExpression(byExpression.expression, subContext);
-                        var lambdaBody = Expression.Convert(sortMemberExpression, typeof(object));
-                        var sortLambda = System.Linq.Expressions.Expression.Lambda(lambdaBody, sortMemberParameter);
-                        var sort = OperatorBinding.Bind(CqlOperator.SortBy, ctx.RuntimeContextParameter,
-                            @return, sortLambda, Expression.Constant(order, typeof(ListSortDirection)));
-                        @return = sort;
-                    }
-                    else if (by is ByColumn byColumn)
-                    {
-                        var parameterName = "@this";
-                        var returnElementType = TypeResolver.GetListElementType(@return.Type, true)!;
-                        var sortMemberParameter = Expression.Parameter(returnElementType, parameterName);
-                        var pathMemberType = TypeManager.TypeFor(byColumn, ctx);
-                        if (pathMemberType == null)
-                        {
-                            var msg = $"Type specifier {by.resultTypeName} at {by.locator ?? "unknown"} could not be resolved.";
-                            ctx.LogError(msg);
-                            throw new InvalidOperationException(msg);
-                        }
-                        var pathExpression = PropertyHelper(sortMemberParameter, byColumn.path, pathMemberType!, ctx);
-                        var lambdaBody = Expression.Convert(pathExpression, typeof(object));
-                        var sortLambda = System.Linq.Expressions.Expression.Lambda(lambdaBody, sortMemberParameter);
-                        var sort = OperatorBinding.Bind(CqlOperator.SortBy, ctx.RuntimeContextParameter,
-                            @return, sortLambda, Expression.Constant(order, typeof(ListSortDirection)));
-                        @return = sort;
-                    }
-                    else
-                    {
-                        var sort = OperatorBinding.Bind(CqlOperator.Sort, ctx.RuntimeContextParameter,
-                            @return, Expression.Constant(order, typeof(ListSortDirection)));
-                        @return = sort;
-                    }
-                }
-            }
+            @return = HandleQuerySort(query, @return, ctx);
 
             if (isSingle)
             {
@@ -1236,6 +1192,71 @@ namespace Hl7.Cql.Compiler
 
             return @return;
         }
+        protected Expression HandleQuerySort(Query query, Expression source, ExpressionBuilderContext ctx)
+        {
+            if (query?.sort == null || query.sort.by == null || query.sort.by.Length == 0)
+                return source;
+
+            Type elementType = TypeResolver.GetListElementType(source.Type, @throw: true)!;
+            var parameterName = "@this";
+
+            // Create a list to hold tuples of (keySelector, direction)
+            var sortExpressions = new List<(Expression keySelector, Expression direction)>();
+
+            foreach (var by in query.sort.by)
+            {
+                ListSortDirection order = ExtensionMethods.ListSortOrder(by.direction);
+                Expression sortKeySelector;
+
+                if (by is ByExpression byExpression)
+                {
+                    var sortMemberParameter = Expression.Parameter(elementType, parameterName);
+                    var subContext = ctx.WithImpliedAlias(parameterName!, sortMemberParameter, byExpression.expression);
+                    var sortMemberExpression = TranslateExpression(byExpression.expression, subContext);
+                    var lambdaBody = Expression.Convert(sortMemberExpression, typeof(object));
+                    sortKeySelector = Expression.Lambda(lambdaBody, sortMemberParameter);
+                }
+                else if (by is ByColumn byColumn)
+                {
+                    var sortMemberParameter = Expression.Parameter(elementType, parameterName);
+                    var pathMemberType = TypeManager.TypeFor(byColumn, ctx);
+                    if (pathMemberType == null)
+                    {
+                        var msg = $"Type specifier {by.resultTypeName} at {by.locator ?? "unknown"} could not be resolved.";
+                        ctx.LogError(msg);
+                        throw new InvalidOperationException(msg);
+                    }
+                    var pathExpression = PropertyHelper(sortMemberParameter, byColumn.path, pathMemberType!, ctx);
+                    var lambdaBody = Expression.Convert(pathExpression, typeof(object));
+                    sortKeySelector = Expression.Lambda(lambdaBody, sortMemberParameter);
+                }
+                else
+                {
+                    // Simple sort without a key selector
+                    return OperatorBinding.Bind(CqlOperator.Sort, ctx.RuntimeContextParameter,
+                        source, Expression.Constant(order, typeof(ListSortDirection)));
+                }
+
+                sortExpressions.Add((sortKeySelector, Expression.Constant(order, typeof(ListSortDirection))));
+            }
+
+            // If we have just one sort expression, use the simple SortBy
+            if (sortExpressions.Count == 1)
+            {
+                return OperatorBinding.Bind(CqlOperator.SortBy, ctx.RuntimeContextParameter,
+                    source, sortExpressions[0].keySelector, sortExpressions[0].direction);
+            }
+
+            // For multiple sort expressions, use the SortByMultiple operator
+            var keySelectorArray = Expression.NewArrayInit(typeof(Delegate),
+                sortExpressions.Select(se => se.keySelector));
+            var directionsArray = Expression.NewArrayInit(typeof(ListSortDirection),
+                sortExpressions.Select(se => se.direction));
+
+            return OperatorBinding.Bind(CqlOperator.SortByMultiple, ctx.RuntimeContextParameter,
+                source, keySelectorArray, directionsArray);
+        }
+
         protected Expression MultiSourceQuery(Query query, ExpressionBuilderContext ctx)
         {
             // The technique here is to create a cross product of all the query sources.

--- a/Cql/Cql.Compiler/ExpressionBuilder.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.cs
@@ -1200,8 +1200,8 @@ namespace Hl7.Cql.Compiler
             Type elementType = TypeResolver.GetListElementType(source.Type, @throw: true)!;
             var parameterName = "@this";
 
-            // Create a list to hold tuples of (keySelector, direction)
-            var sortInstructions = new List<(Expression sortExpression, Expression direction)>();
+            // Create a list to hold tuples of (keySelector, direction)  
+            var sortInstructions = new List<(Expression sortExpression, ListSortDirection direction)>();
 
             foreach (var by in query.sort.by)
             {
@@ -1232,22 +1232,27 @@ namespace Hl7.Cql.Compiler
                 }
                 else
                 {
-                    // Simple sort without a key selector
+                    // Simple sort without a key selector  
                     return OperatorBinding.Bind(CqlOperator.Sort, ctx.RuntimeContextParameter,
                         source, Expression.Constant(order, typeof(ListSortDirection)));
                 }
 
-                sortInstructions.Add((sortKeySelector, Expression.Constant(order, typeof(ListSortDirection))));
+                sortInstructions.Add((sortKeySelector, order));
             }
 
-            // If we have just one sort expression, use the simple SortBy
+            // If we have just one sort expression, use the simple SortBy  
             if (sortInstructions.Count == 1)
             {
-                return OperatorBinding.Bind(CqlOperator.SortBy, ctx.RuntimeContextParameter,
-                    source, sortInstructions[0].sortExpression, sortInstructions[0].direction);
+                return OperatorBinding.Bind(
+                    CqlOperator.SortBy,
+                    ctx.RuntimeContextParameter,
+                    source,
+                    sortInstructions[0].sortExpression,
+                    Expression.Constant(sortInstructions[0].direction, typeof(ListSortDirection))
+                );
             }
 
-            // For multiple sort expressions, use the SortByMultiple operator
+            // For multiple sort expressions, use the SortByMultiple operator  
             var keySelectorList = Expression.ListInit(
                Expression.New(typeof(List<>).MakeGenericType(typeof(Func<,>).MakeGenericType(elementType, typeof(object)))),
                sortInstructions.Select(se => se.sortExpression)
@@ -1255,7 +1260,7 @@ namespace Hl7.Cql.Compiler
 
             var directionsList = Expression.ListInit(
                Expression.New(typeof(List<ListSortDirection>)),
-               sortInstructions.Select(se => se.direction)
+               sortInstructions.Select(se => Expression.Constant(se.direction, typeof(ListSortDirection)))
             );
 
             return OperatorBinding.Bind(CqlOperator.SortByMultiple, ctx.RuntimeContextParameter,

--- a/Cql/Cql.Compiler/ExpressionBuilder.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.cs
@@ -1201,7 +1201,7 @@ namespace Hl7.Cql.Compiler
             var parameterName = "@this";
 
             // Create a list to hold tuples of (keySelector, direction)
-            var sortExpressions = new List<(Expression keySelector, Expression direction)>();
+            var sortInstructions = new List<(Expression sortExpression, Expression direction)>();
 
             foreach (var by in query.sort.by)
             {
@@ -1237,25 +1237,29 @@ namespace Hl7.Cql.Compiler
                         source, Expression.Constant(order, typeof(ListSortDirection)));
                 }
 
-                sortExpressions.Add((sortKeySelector, Expression.Constant(order, typeof(ListSortDirection))));
+                sortInstructions.Add((sortKeySelector, Expression.Constant(order, typeof(ListSortDirection))));
             }
 
             // If we have just one sort expression, use the simple SortBy
-            if (sortExpressions.Count == 1)
+            if (sortInstructions.Count == 1)
             {
                 return OperatorBinding.Bind(CqlOperator.SortBy, ctx.RuntimeContextParameter,
-                    source, sortExpressions[0].keySelector, sortExpressions[0].direction);
+                    source, sortInstructions[0].sortExpression, sortInstructions[0].direction);
             }
 
             // For multiple sort expressions, use the SortByMultiple operator
+            var keySelectorList = Expression.ListInit(
+               Expression.New(typeof(List<>).MakeGenericType(typeof(Func<,>).MakeGenericType(elementType, typeof(object)))),
+               sortInstructions.Select(se => se.sortExpression)
+            );
 
-            var keySelectorArray = Expression.NewArrayInit(typeof(Func<,>).MakeGenericType(elementType, typeof(object)),
-                sortExpressions.Select(se => se.keySelector));
-            var directionsArray = Expression.NewArrayInit(typeof(ListSortDirection),
-                sortExpressions.Select(se => se.direction));
+            var directionsList = Expression.ListInit(
+               Expression.New(typeof(List<ListSortDirection>)),
+               sortInstructions.Select(se => se.direction)
+            );
 
             return OperatorBinding.Bind(CqlOperator.SortByMultiple, ctx.RuntimeContextParameter,
-                source, keySelectorArray, directionsArray);
+                source, keySelectorList, directionsList);
         }
 
         protected Expression MultiSourceQuery(Query query, ExpressionBuilderContext ctx)

--- a/Cql/Cql.Compiler/ExpressionBuilder.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.cs
@@ -1248,7 +1248,8 @@ namespace Hl7.Cql.Compiler
             }
 
             // For multiple sort expressions, use the SortByMultiple operator
-            var keySelectorArray = Expression.NewArrayInit(typeof(Delegate),
+
+            var keySelectorArray = Expression.NewArrayInit(typeof(Func<,>).MakeGenericType(elementType, typeof(object)),
                 sortExpressions.Select(se => se.keySelector));
             var directionsArray = Expression.NewArrayInit(typeof(ListSortDirection),
                 sortExpressions.Select(se => se.direction));

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -1218,82 +1218,44 @@ namespace Hl7.Cql.Runtime
             else throw new NotSupportedException($"Unknown sort order {order}");
         }
 
-        public IEnumerable<T>? ListSortBy<T>(IEnumerable<T>? source, Func<T, object> sortByExpr, ListSortDirection order)
+        public IOrderedEnumerable<T>? ListSortBy<T>(IEnumerable<T>? source, Func<T, object> sortByExpr, ListSortDirection sortDirection)
         {
             if (source == null)
                 return null;
-            if (order == ListSortDirection.Ascending)
+            if (sortDirection == ListSortDirection.Ascending)
             {
                 var nullRecords = source.Where(s => sortByExpr(s) == null);
                 var nonNullRecords = source.Where(s => sortByExpr(s) != null);
                 var ordered = nonNullRecords.OrderBy(source => sortByExpr(source), DataComparer);
-                var result = nullRecords.Concat(ordered);
-                return result;
+                return ordered.Concat(nullRecords).OrderBy(x => 0); // Ensure the return type is IOrderedEnumerable<T>
             }
-            else if (order == ListSortDirection.Descending)
+            else if (sortDirection == ListSortDirection.Descending)
             {
                 var nullRecords = source.Where(s => sortByExpr(s) == null);
                 var nonNullRecords = source.Where(s => sortByExpr(s) != null);
                 var ordered = nonNullRecords.OrderByDescending(source => sortByExpr(source), DataComparer);
-                var result = ordered.Concat(nullRecords);
-                return result;
+                return ordered.Concat(nullRecords).OrderBy(x => 0); // Ensure the return type is IOrderedEnumerable<T>
             }
-            else throw new NotSupportedException($"Unknown sort order {order}");
+            else throw new NotSupportedException($"Unknown sort order {sortDirection}");
         }
 
-        public IEnumerable<T>? ListSortByMultiple<T>(IEnumerable<T> source, IEnumerable<Delegate> sortByExpressions, IEnumerable<ListSortDirection> sortDirections)
+        public IEnumerable<T>? ListThenBy<T>(IOrderedEnumerable<T>? source, Func<T, object> sortByExpr, ListSortDirection sortDirection)
         {
-            if (source == null || !source.Any() || sortByExpressions == null || !sortByExpressions.Any() || sortDirections == null || !sortDirections.Any())
-            {
+            if (source == null || sortByExpr == null)
                 return null;
-            }
 
-            var sortByExpressionList = sortByExpressions.ToList();
-            var sortDirectionList = sortDirections.ToList();
-
-            if (sortByExpressionList.Count != sortDirectionList.Count)
+            if (sortDirection == ListSortDirection.Ascending)
             {
-                throw new ArgumentException("The number of sort expressions must match the number of sort directions.");
+                return source.ThenBy(sortByExpr);
             }
-
-            IOrderedEnumerable<T>? orderedSource = null;
-            for (int i = 0; i < sortByExpressionList.Count; i++)
+            else if (sortDirection == ListSortDirection.Descending)
             {
-                if (sortByExpressionList[i] is not Func<T, object> sortByDelegate)
-                {
-                    throw new InvalidCastException($"The sort expression at index {i} is not of type Func<T, object>.");
-                }
-
-                var sortDirection = sortDirectionList[i];
-
-                if (i == 0)
-                {
-                    if (sortDirection == ListSortDirection.Ascending)
-                    {
-                        orderedSource = source.OrderBy(sortByDelegate);
-                    }
-                    else
-                    {
-                        orderedSource = source.OrderByDescending(sortByDelegate);
-                    }
-                }
-                else
-                {
-                    if (orderedSource != null) // Ensure orderedSource is not null before calling ThenBy  
-                    {
-                        if (sortDirection == ListSortDirection.Ascending)
-                        {
-                            orderedSource = orderedSource.ThenBy(sortByDelegate);
-                        }
-                        else
-                        {
-                            orderedSource = orderedSource.ThenByDescending(sortByDelegate);
-                        }
-                    }
-                }
+                return source.ThenByDescending(sortByExpr);
             }
-
-            return orderedSource;
+            else
+            {
+                throw new NotSupportedException($"Unknown sort order {sortDirection}");
+            }
         }
 
         #endregion

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -1242,7 +1242,7 @@ namespace Hl7.Cql.Runtime
             else throw new NotSupportedException($"Unknown sort order {sortDirection}");
         }
 
-        public IEnumerable<T>? ListThenBy<T>(IOrderedEnumerable<T>? source, Func<T, object> sortByExpr, ListSortDirection sortDirection)
+        public IOrderedEnumerable<T>? ListThenBy<T>(IOrderedEnumerable<T>? source, Func<T, object> sortByExpr, ListSortDirection sortDirection)
         {
             if (source == null || sortByExpr == null)
                 return null;

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -1222,22 +1222,20 @@ namespace Hl7.Cql.Runtime
         {
             if (source == null)
                 return null;
+
+            // Nulls first, then by sortByExpr ascending
+            var nullOrdered = source.OrderBy(x => x == null ? 0 : 1);
+
             if (sortDirection == ListSortDirection.Ascending)
             {
-                var nullRecords = source.Where(s => sortByExpr(s) == null);
-                var nonNullRecords = source.Where(s => sortByExpr(s) != null);
-                var ordered = nonNullRecords.OrderBy(source => sortByExpr(source), DataComparer);
-                var orderedList = nullRecords.Concat(ordered).OrderBy(x => 0); // Ensure the return type is IOrderedEnumerable<T> and nulls are first
+                var orderedList = nullOrdered.ThenBy(source => sortByExpr(source), DataComparer);
                 return orderedList;
 
             }
             else if (sortDirection == ListSortDirection.Descending)
             {
-                var nullRecords = source.Where(s => sortByExpr(s) == null);
-                var nonNullRecords = source.Where(s => sortByExpr(s) != null);
-                var ordered = nonNullRecords.OrderByDescending(source => sortByExpr(source), DataComparer);
-                var orderedlist = nullRecords.Concat(ordered).OrderBy(x => 0); // Ensure the return type is IOrderedEnumerable<T> and nulls are first
-                return orderedlist;
+                var orderedList = nullOrdered.ThenByDescending(source => sortByExpr(source), DataComparer);
+                return orderedList;
             }
             else throw new NotSupportedException($"Unknown sort order {sortDirection}");
         }
@@ -1247,19 +1245,18 @@ namespace Hl7.Cql.Runtime
             if (source == null || sortByExpr == null)
                 return null;
 
+            // Nulls first, then by sortByExpr ascending
+            var nullOrdered = source.ThenBy(x => sortByExpr(x) == null ? 0 : 1);
+
             if (sortDirection == ListSortDirection.Ascending)
             {
-                // Nulls first, then by sortByExpr ascending
-                return source
-                    .ThenBy(x => sortByExpr(x) == null ? 0 : 1)
-                    .ThenBy(sortByExpr);
+                return nullOrdered
+                    .ThenBy(sortByExpr, DataComparer);
             }
             else if (sortDirection == ListSortDirection.Descending)
             {
-                // Nulls first, then by sortByExpr descending
-                return source
-                    .ThenBy(x => sortByExpr(x) == null ? 0 : 1)
-                    .ThenByDescending(sortByExpr);
+                return nullOrdered
+                    .ThenByDescending(sortByExpr, DataComparer); ;
             }
             else
             {

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -1241,6 +1241,52 @@ namespace Hl7.Cql.Runtime
             else throw new NotSupportedException($"Unknown sort order {order}");
         }
 
+        public IEnumerable<T>? ListSortByMultiple<T>(IEnumerable<T> source, IEnumerable<(Func<T, object> SortBy, ListSortDirection Direction)> sortInstructions)
+        {
+            if (source == null || !source.Any() || sortInstructions == null || !sortInstructions.Any())
+            {
+                return null;
+            }
+
+            IOrderedEnumerable<T>? orderedSource = null;
+            bool isFirst = true;
+
+            foreach (var instruction in sortInstructions)
+            {
+                var sortByDelegate = instruction.SortBy;
+                var sortDirection = instruction.Direction;
+
+                if (isFirst)
+                {
+                    if (sortDirection == ListSortDirection.Ascending)
+                    {
+                        orderedSource = source.OrderBy(sortByDelegate);
+                    }
+                    else
+                    {
+                        orderedSource = source.OrderByDescending(sortByDelegate);
+                    }
+                    isFirst = false;
+                }
+                else
+                {
+                    if (orderedSource != null) // Ensure orderedSource is not null before calling ThenBy  
+                    {
+                        if (sortDirection == ListSortDirection.Ascending)
+                        {
+                            orderedSource = orderedSource.ThenBy(sortByDelegate);
+                        }
+                        else
+                        {
+                            orderedSource = orderedSource.ThenByDescending(sortByDelegate);
+                        }
+                    }
+                }
+            }
+
+            return orderedSource;
+        }
+
         #endregion
 
     }

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -1241,22 +1241,32 @@ namespace Hl7.Cql.Runtime
             else throw new NotSupportedException($"Unknown sort order {order}");
         }
 
-        public IEnumerable<T>? ListSortByMultiple<T>(IEnumerable<T> source, IEnumerable<(Func<T, object> SortBy, ListSortDirection Direction)> sortInstructions)
+        public IEnumerable<T>? ListSortByMultiple<T>(IEnumerable<T> source, IEnumerable<Delegate> sortByExpressions, IEnumerable<ListSortDirection> sortDirections)
         {
-            if (source == null || !source.Any() || sortInstructions == null || !sortInstructions.Any())
+            if (source == null || !source.Any() || sortByExpressions == null || !sortByExpressions.Any() || sortDirections == null || !sortDirections.Any())
             {
                 return null;
             }
 
-            IOrderedEnumerable<T>? orderedSource = null;
-            bool isFirst = true;
+            var sortByExpressionList = sortByExpressions.ToList();
+            var sortDirectionList = sortDirections.ToList();
 
-            foreach (var instruction in sortInstructions)
+            if (sortByExpressionList.Count != sortDirectionList.Count)
             {
-                var sortByDelegate = instruction.SortBy;
-                var sortDirection = instruction.Direction;
+                throw new ArgumentException("The number of sort expressions must match the number of sort directions.");
+            }
 
-                if (isFirst)
+            IOrderedEnumerable<T>? orderedSource = null;
+            for (int i = 0; i < sortByExpressionList.Count; i++)
+            {
+                if (sortByExpressionList[i] is not Func<T, object> sortByDelegate)
+                {
+                    throw new InvalidCastException($"The sort expression at index {i} is not of type Func<T, object>.");
+                }
+
+                var sortDirection = sortDirectionList[i];
+
+                if (i == 0)
                 {
                     if (sortDirection == ListSortDirection.Ascending)
                     {
@@ -1266,7 +1276,6 @@ namespace Hl7.Cql.Runtime
                     {
                         orderedSource = source.OrderByDescending(sortByDelegate);
                     }
-                    isFirst = false;
                 }
                 else
                 {

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -1227,14 +1227,17 @@ namespace Hl7.Cql.Runtime
                 var nullRecords = source.Where(s => sortByExpr(s) == null);
                 var nonNullRecords = source.Where(s => sortByExpr(s) != null);
                 var ordered = nonNullRecords.OrderBy(source => sortByExpr(source), DataComparer);
-                return ordered.Concat(nullRecords).OrderBy(x => 0); // Ensure the return type is IOrderedEnumerable<T>
+                var orderedList = nullRecords.Concat(ordered).OrderBy(x => 0); // Ensure the return type is IOrderedEnumerable<T> and nulls are first
+                return orderedList;
+
             }
             else if (sortDirection == ListSortDirection.Descending)
             {
                 var nullRecords = source.Where(s => sortByExpr(s) == null);
                 var nonNullRecords = source.Where(s => sortByExpr(s) != null);
                 var ordered = nonNullRecords.OrderByDescending(source => sortByExpr(source), DataComparer);
-                return ordered.Concat(nullRecords).OrderBy(x => 0); // Ensure the return type is IOrderedEnumerable<T>
+                var orderedlist = nullRecords.Concat(ordered).OrderBy(x => 0); // Ensure the return type is IOrderedEnumerable<T> and nulls are first
+                return orderedlist;
             }
             else throw new NotSupportedException($"Unknown sort order {sortDirection}");
         }
@@ -1246,11 +1249,17 @@ namespace Hl7.Cql.Runtime
 
             if (sortDirection == ListSortDirection.Ascending)
             {
-                return source.ThenBy(sortByExpr);
+                // Nulls first, then by sortByExpr ascending
+                return source
+                    .ThenBy(x => sortByExpr(x) == null ? 0 : 1)
+                    .ThenBy(sortByExpr);
             }
             else if (sortDirection == ListSortDirection.Descending)
             {
-                return source.ThenByDescending(sortByExpr);
+                // Nulls first, then by sortByExpr descending
+                return source
+                    .ThenBy(x => sortByExpr(x) == null ? 0 : 1)
+                    .ThenByDescending(sortByExpr);
             }
             else
             {

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -1224,7 +1224,7 @@ namespace Hl7.Cql.Runtime
                 return null;
 
             // Nulls first, then by sortByExpr ascending
-            var nullOrdered = source.OrderBy(x => x == null ? 0 : 1);
+            var nullOrdered = source.OrderBy(x => sortByExpr(x) == null ? 0 : 1);
 
             if (sortDirection == ListSortDirection.Ascending)
             {

--- a/Cql/Cql.Operators/ICqlOperators.cs
+++ b/Cql/Cql.Operators/ICqlOperators.cs
@@ -324,7 +324,7 @@ namespace Hl7.Cql.Operators
         IEnumerable<T>? ListSkip<T>(IEnumerable<T> argument, int? number);
         IEnumerable<T>? ListSort<T>(IEnumerable<T>? source, ListSortDirection order);
         IEnumerable<T>? ListSortBy<T>(IEnumerable<T>? source, Func<T, object> sortByExpr, ListSortDirection order);
-        IEnumerable<T>? ListSortByMultiple<T>(IEnumerable<T> source, IEnumerable<(Func<T, object> SortBy, ListSortDirection Direction)> sortInstructions);
+        IEnumerable<T>? ListSortByMultiple<T>(IEnumerable<T> source, IEnumerable<Delegate> sortByExpressions, IEnumerable<ListSortDirection> sortDirections);
         IEnumerable<T>? ListTail<T>(IEnumerable<T> argument);
         IEnumerable<T>? ListTake<T>(IEnumerable<T> argument, int? number);
         IEnumerable<T>? ListUnion<T>(IEnumerable<T>? left, IEnumerable<T>? right);

--- a/Cql/Cql.Operators/ICqlOperators.cs
+++ b/Cql/Cql.Operators/ICqlOperators.cs
@@ -324,6 +324,7 @@ namespace Hl7.Cql.Operators
         IEnumerable<T>? ListSkip<T>(IEnumerable<T> argument, int? number);
         IEnumerable<T>? ListSort<T>(IEnumerable<T>? source, ListSortDirection order);
         IEnumerable<T>? ListSortBy<T>(IEnumerable<T>? source, Func<T, object> sortByExpr, ListSortDirection order);
+        IEnumerable<T>? ListSortByMultiple<T>(IEnumerable<T> source, IEnumerable<(Func<T, object> SortBy, ListSortDirection Direction)> sortInstructions);
         IEnumerable<T>? ListTail<T>(IEnumerable<T> argument);
         IEnumerable<T>? ListTake<T>(IEnumerable<T> argument, int? number);
         IEnumerable<T>? ListUnion<T>(IEnumerable<T>? left, IEnumerable<T>? right);

--- a/Cql/Cql.Operators/ICqlOperators.cs
+++ b/Cql/Cql.Operators/ICqlOperators.cs
@@ -325,7 +325,7 @@ namespace Hl7.Cql.Operators
         IEnumerable<T>? ListSkip<T>(IEnumerable<T> argument, int? number);
         IEnumerable<T>? ListSort<T>(IEnumerable<T>? source, ListSortDirection order);
         IOrderedEnumerable<T>? ListSortBy<T>(IEnumerable<T>? source, Func<T, object> sortByExpr, ListSortDirection sortDirection);
-        IEnumerable<T>? ListThenBy<T>(IOrderedEnumerable<T>? source, Func<T, object> sortByExpr, ListSortDirection sortDirection);
+        IOrderedEnumerable<T>? ListThenBy<T>(IOrderedEnumerable<T>? source, Func<T, object> sortByExpr, ListSortDirection sortDirection);
         IEnumerable<T>? ListTail<T>(IEnumerable<T> argument);
         IEnumerable<T>? ListTake<T>(IEnumerable<T> argument, int? number);
         IEnumerable<T>? ListUnion<T>(IEnumerable<T>? left, IEnumerable<T>? right);

--- a/Cql/Cql.Operators/ICqlOperators.cs
+++ b/Cql/Cql.Operators/ICqlOperators.cs
@@ -4,6 +4,7 @@ using Hl7.Cql.Primitives;
 using Hl7.Cql.ValueSets;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using ListSortDirection = System.ComponentModel.ListSortDirection;
 
@@ -323,8 +324,8 @@ namespace Hl7.Cql.Operators
         bool? ListProperlyIncludesList<T>(IEnumerable<T>? left, IEnumerable<T> right);
         IEnumerable<T>? ListSkip<T>(IEnumerable<T> argument, int? number);
         IEnumerable<T>? ListSort<T>(IEnumerable<T>? source, ListSortDirection order);
-        IEnumerable<T>? ListSortBy<T>(IEnumerable<T>? source, Func<T, object> sortByExpr, ListSortDirection order);
-        IEnumerable<T>? ListSortByMultiple<T>(IEnumerable<T> source, IEnumerable<Delegate> sortByExpressions, IEnumerable<ListSortDirection> sortDirections);
+        IOrderedEnumerable<T>? ListSortBy<T>(IEnumerable<T>? source, Func<T, object> sortByExpr, ListSortDirection sortDirection);
+        IEnumerable<T>? ListThenBy<T>(IOrderedEnumerable<T>? source, Func<T, object> sortByExpr, ListSortDirection sortDirection);
         IEnumerable<T>? ListTail<T>(IEnumerable<T> argument);
         IEnumerable<T>? ListTake<T>(IEnumerable<T> argument, int? number);
         IEnumerable<T>? ListUnion<T>(IEnumerable<T>? left, IEnumerable<T>? right);


### PR DESCRIPTION
Fix: Correct Multi-Level Sorting for CQL 'sort by'

* **Issue:** Previously, the generated C# code for CQL `sort by` expressions with multiple criteria incorrectly handled the sort hierarchy. Instead of applying secondary sorts, each criterion effectively re-sorted the list, losing the intended multi-level order.
* **Resolution:** This PR updates the code generator to correctly translate the multi-level sorting.
    * The first `sort by` expression now uses `ListSortBy`.
    * All subsequent `sort by` expressions now use `ListThenBy` on the result of the previous sort operation.
* **Benefit:** This approach correctly builds a stable multi-level sort chain. It ensures each criterion refines the order within the hierarchy established by the preceding ones, and that custom sorting logic (like placing null values first) is correctly applied at each level.

Example:

Given the following CQL:
```
define function Sorting (observations List<FHIR.Observation>):
    observations observation
    sort by
        effective asc,
        status desc
```

The corresponding C# implementation is now correctly generated as:
```
public IEnumerable<Observation> Sorting(CqlContext context, IEnumerable<Observation> observations)
{
    object a_(Observation @this) => @this?.Effective;
    var b_ = context.Operators.ListSortBy<Observation>(observations, a_, System.ComponentModel.ListSortDirection.Ascending);

    object c_(Observation @this) => @this?.StatusElement;
    var d_ = context.Operators.ListThenBy<Observation>(b_, c_, System.ComponentModel.ListSortDirection.Descending);

    return (d_ as IEnumerable<Observation>);
}
```

This fix aligns the generated C# sorting logic precisely with the multi-level sorting specified in the CQL definition.