### PR TITLE
Fix ucum unit normalization

### DIFF
--- a/Cql/CoreTests/ModelTest.cs
+++ b/Cql/CoreTests/ModelTest.cs
@@ -33,7 +33,7 @@ namespace CoreTests
             var ctx = new CqlContext(CqlOperators.Create(new UnitTestTypeResolver(),
                 dataSource: dataSource,
                 now: new DateTimeIso8601(2023, 3, 28, null, null, null, null, null, null)));
-            var age = ctx.Operators.Age("a");
+            var age = ctx.Operators.Age("year");
             Assert.AreEqual(age, 39);
         }
 
@@ -48,7 +48,7 @@ namespace CoreTests
             var ctx = new CqlContext(CqlOperators.Create(new UnitTestTypeResolver(),
                 dataSource: dataSource,
                 now: new DateTimeIso8601(2023, 3, 28, null, null, null, null, null, null)));
-            var age = ctx.Operators.AgeAt(new CqlDate(2013, 3, 28), "a");
+            var age = ctx.Operators.AgeAt(new CqlDate(2013, 3, 28), "year");
             Assert.AreEqual(age, 29);
         }
 

--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -3113,11 +3113,11 @@ namespace CoreTests
             {
                 new CqlInterval<CqlTime>(start, end, true, true)
             };
-            var quantity = new CqlQuantity(2, "years");
+            var perQuantity = new CqlQuantity(2, "year");
 
             var rc = GetNewContext(); var fcq = rc.Operators;
 
-            var expand = fcq.ExpandList(interval, quantity);
+            var expand = fcq.ExpandList(interval, perQuantity);
             Assert.IsNotNull(expand);
             Assert.IsTrue(expand.Count() == 0);
         }

--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -1234,11 +1234,11 @@ namespace CoreTests
             var end = new CqlTime(12, null, null, null, null, null);
 
             var interval = new CqlInterval<CqlTime>(start, end, true, true);
-            var quantity = new CqlQuantity(2, "years");
+            var perQuantity = new CqlQuantity(2, "year");
 
             var rc = GetNewContext(); var fcq = rc.Operators;
 
-            var expand = fcq.ExpandInterval(interval, quantity);
+            var expand = fcq.ExpandInterval(interval, perQuantity);
             Assert.IsNotNull(expand);
             Assert.IsTrue(expand.Count() == 0);
         }

--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -1093,7 +1093,7 @@ namespace CoreTests
             var end = new CqlDateTime(2022, 1, 1, 0, 0, 6, 0, 0, 0);
 
             var interval = new CqlInterval<CqlDateTime>(start, end, true, true);
-            var quantity = new CqlQuantity(3, "secondd");
+            var quantity = new CqlQuantity(3, "second");
             var expected = new List<CqlDateTime>
             {
                 new CqlDateTime(2022,1,1,0,0,0,0,0,0),

--- a/Cql/CoreTests/UcumTests.cs
+++ b/Cql/CoreTests/UcumTests.cs
@@ -18,10 +18,10 @@ namespace CoreTests
             canonical.value.Should().Be(3.14M * 1000.0M);
 
             q = new CqlQuantity(2.5M, "h");
+            q.unit.Should().BeNull();
             success = q.TryCanonicalize(out canonical);
-            success.Should().BeTrue();
-            canonical.unit.Should().Be("s");
-            canonical.value.Should().Be(2.5M * 60.0M * 60.0M);
+            success.Should().BeFalse();
+            canonical.Should().BeNull();
         }
 
         [TestMethod, Ignore]

--- a/Cql/Cql.Abstractions/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.Abstractions/PublicAPI.Unshipped.txt
@@ -3,20 +3,12 @@ abstract Hl7.Cql.Abstractions.TypeResolver.GetListElementType(System.Type! type,
 abstract Hl7.Cql.Abstractions.TypeResolver.ImplementsGenericInterface(System.Type! type, System.Type! genericInterfaceTypeDefinition) -> bool
 abstract Hl7.Cql.Abstractions.TypeResolver.ResolveType(string! typeSpecifier) -> System.Type?
 const Hl7.Cql.Abstractions.UCUMUnits.Centimeter = "cm" -> string!
-#const Hl7.Cql.Abstractions.UCUMUnits.Day = "d" -> string!
 const Hl7.Cql.Abstractions.UCUMUnits.Default = "1" -> string!
 const Hl7.Cql.Abstractions.UCUMUnits.Foot = "[ft_i]" -> string!
-#const Hl7.Cql.Abstractions.UCUMUnits.Hour = "h" -> string!
 const Hl7.Cql.Abstractions.UCUMUnits.Inch = "[in_i]" -> string!
 const Hl7.Cql.Abstractions.UCUMUnits.Meter = "m" -> string!
-#const Hl7.Cql.Abstractions.UCUMUnits.Millisecond = "ms" -> string!
-#const Hl7.Cql.Abstractions.UCUMUnits.Minute = "min" -> string!
-#const Hl7.Cql.Abstractions.UCUMUnits.Month = "mo" -> string!
-#const Hl7.Cql.Abstractions.UCUMUnits.Second = "s" -> string!
 const Hl7.Cql.Abstractions.UCUMUnits.Unary = "1" -> string!
-#const Hl7.Cql.Abstractions.UCUMUnits.Week = "wk" -> string!
 const Hl7.Cql.Abstractions.UCUMUnits.Yard = "[yd_i]" -> string!
-#const Hl7.Cql.Abstractions.UCUMUnits.Year = "a" -> string!
 Hl7.Cql.Abstractions.CqlDeclarationAttribute
 Hl7.Cql.Abstractions.CqlDeclarationAttribute.CqlDeclarationAttribute(string! Name) -> void
 Hl7.Cql.Abstractions.CqlDeclarationAttribute.Name.get -> string!
@@ -51,6 +43,3 @@ Hl7.Cql.Abstractions.TypeResolver
 Hl7.Cql.Abstractions.TypeResolver.TypeResolver() -> void
 Hl7.Cql.Abstractions.UCUMUnits
 Hl7.Cql.Abstractions.Units
-static Hl7.Cql.Abstractions.UCUMUnits.FromDateTimePrecision(Hl7.Cql.Iso8601.DateTimePrecision dtp) -> string?
-#static readonly Hl7.Cql.Abstractions.Units.CqlUnitsToUCUM -> System.Collections.Generic.IDictionary<string!, string!>!
-#static readonly Hl7.Cql.Abstractions.Units.UCUMUnitsToCql -> System.Collections.Generic.IDictionary<string!, string!>!

--- a/Cql/Cql.Abstractions/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.Abstractions/PublicAPI.Unshipped.txt
@@ -3,20 +3,20 @@ abstract Hl7.Cql.Abstractions.TypeResolver.GetListElementType(System.Type! type,
 abstract Hl7.Cql.Abstractions.TypeResolver.ImplementsGenericInterface(System.Type! type, System.Type! genericInterfaceTypeDefinition) -> bool
 abstract Hl7.Cql.Abstractions.TypeResolver.ResolveType(string! typeSpecifier) -> System.Type?
 const Hl7.Cql.Abstractions.UCUMUnits.Centimeter = "cm" -> string!
-const Hl7.Cql.Abstractions.UCUMUnits.Day = "d" -> string!
+#const Hl7.Cql.Abstractions.UCUMUnits.Day = "d" -> string!
 const Hl7.Cql.Abstractions.UCUMUnits.Default = "1" -> string!
 const Hl7.Cql.Abstractions.UCUMUnits.Foot = "[ft_i]" -> string!
-const Hl7.Cql.Abstractions.UCUMUnits.Hour = "h" -> string!
+#const Hl7.Cql.Abstractions.UCUMUnits.Hour = "h" -> string!
 const Hl7.Cql.Abstractions.UCUMUnits.Inch = "[in_i]" -> string!
 const Hl7.Cql.Abstractions.UCUMUnits.Meter = "m" -> string!
-const Hl7.Cql.Abstractions.UCUMUnits.Millisecond = "ms" -> string!
-const Hl7.Cql.Abstractions.UCUMUnits.Minute = "min" -> string!
-const Hl7.Cql.Abstractions.UCUMUnits.Month = "mo" -> string!
-const Hl7.Cql.Abstractions.UCUMUnits.Second = "s" -> string!
+#const Hl7.Cql.Abstractions.UCUMUnits.Millisecond = "ms" -> string!
+#const Hl7.Cql.Abstractions.UCUMUnits.Minute = "min" -> string!
+#const Hl7.Cql.Abstractions.UCUMUnits.Month = "mo" -> string!
+#const Hl7.Cql.Abstractions.UCUMUnits.Second = "s" -> string!
 const Hl7.Cql.Abstractions.UCUMUnits.Unary = "1" -> string!
-const Hl7.Cql.Abstractions.UCUMUnits.Week = "wk" -> string!
+#const Hl7.Cql.Abstractions.UCUMUnits.Week = "wk" -> string!
 const Hl7.Cql.Abstractions.UCUMUnits.Yard = "[yd_i]" -> string!
-const Hl7.Cql.Abstractions.UCUMUnits.Year = "a" -> string!
+#const Hl7.Cql.Abstractions.UCUMUnits.Year = "a" -> string!
 Hl7.Cql.Abstractions.CqlDeclarationAttribute
 Hl7.Cql.Abstractions.CqlDeclarationAttribute.CqlDeclarationAttribute(string! Name) -> void
 Hl7.Cql.Abstractions.CqlDeclarationAttribute.Name.get -> string!
@@ -52,5 +52,5 @@ Hl7.Cql.Abstractions.TypeResolver.TypeResolver() -> void
 Hl7.Cql.Abstractions.UCUMUnits
 Hl7.Cql.Abstractions.Units
 static Hl7.Cql.Abstractions.UCUMUnits.FromDateTimePrecision(Hl7.Cql.Iso8601.DateTimePrecision dtp) -> string?
-static readonly Hl7.Cql.Abstractions.Units.CqlUnitsToUCUM -> System.Collections.Generic.IDictionary<string!, string!>!
-static readonly Hl7.Cql.Abstractions.Units.UCUMUnitsToCql -> System.Collections.Generic.IDictionary<string!, string!>!
+#static readonly Hl7.Cql.Abstractions.Units.CqlUnitsToUCUM -> System.Collections.Generic.IDictionary<string!, string!>!
+#static readonly Hl7.Cql.Abstractions.Units.UCUMUnitsToCql -> System.Collections.Generic.IDictionary<string!, string!>!

--- a/Cql/Cql.Abstractions/UCUMUnits.cs
+++ b/Cql/Cql.Abstractions/UCUMUnits.cs
@@ -28,6 +28,38 @@ namespace Hl7.Cql.Abstractions
         public const string Unary = "1";
 
         /// <summary>
+        /// Years (annos in Latin).
+        /// </summary>
+        public const string Year = "a";
+        /// <summary>
+        /// Months
+        /// </summary>
+        public const string Month = "mo";
+        /// <summary>
+        /// Days
+        /// </summary>
+        public const string Day = "d";
+        /// <summary>
+        /// Hours
+        /// </summary>
+        public const string Hour = "h";
+        /// <summary>
+        /// Minutes
+        /// </summary>
+        public const string Minute = "min";
+        /// <summary>
+        /// Seconds
+        /// </summary>
+        public const string Second = "s";
+        /// <summary>
+        /// Milliseconds
+        /// </summary>
+        public const string Millisecond = "ms";
+        /// <summary>
+        /// Weeks, equal to 7 <see cref="Day"/>.
+        /// </summary>
+        public const string Week = "wk";
+        /// <summary>
         /// Imperial inches
         /// </summary>
         public const string Inch = "[in_i]";

--- a/Cql/Cql.Abstractions/UCUMUnits.cs
+++ b/Cql/Cql.Abstractions/UCUMUnits.cs
@@ -83,7 +83,7 @@ namespace Hl7.Cql.Abstractions
         /// <summary>
         /// List of UCUM units commonly used for date and time intervals.
         /// </summary>
-        public static readonly List<string> DateTimeUnits = new List<string>
+        public static readonly HashSet<string> DateTimeUnits = new HashSet<string>
         {
             Year, Month, Day, Hour, Minute, Second, Millisecond
         };

--- a/Cql/Cql.Abstractions/UCUMUnits.cs
+++ b/Cql/Cql.Abstractions/UCUMUnits.cs
@@ -28,38 +28,6 @@ namespace Hl7.Cql.Abstractions
         public const string Unary = "1";
 
         /// <summary>
-        /// Years (annos in Latin).
-        /// </summary>
-        public const string Year = "a";
-        /// <summary>
-        /// Months
-        /// </summary>
-        public const string Month = "mo";
-        /// <summary>
-        /// Days
-        /// </summary>
-        public const string Day = "d";
-        /// <summary>
-        /// Hours
-        /// </summary>
-        public const string Hour = "h";
-        /// <summary>
-        /// Minutes
-        /// </summary>
-        public const string Minute = "min";
-        /// <summary>
-        /// Seconds
-        /// </summary>
-        public const string Second = "s";
-        /// <summary>
-        /// Milliseconds
-        /// </summary>
-        public const string Millisecond = "ms";
-        /// <summary>
-        /// Weeks, equal to 7 <see cref="Day"/>.
-        /// </summary>
-        public const string Week = "wk";
-        /// <summary>
         /// Imperial inches
         /// </summary>
         public const string Inch = "[in_i]";
@@ -79,26 +47,6 @@ namespace Hl7.Cql.Abstractions
         /// Centimeters
         /// </summary>
         public const string Centimeter = "cm";
-
-        /// <summary>
-        /// Maps <see cref="DateTimePrecision"/> to the corresponding UCUM unit.
-        /// </summary>
-        /// <param name="dtp">The precision to map.</param>
-        /// <returns>The corresponding UCUM units, or <see langword="null"/> if no mapping is defined.</returns>
-        public static string? FromDateTimePrecision(DateTimePrecision dtp)
-        {
-            return dtp switch
-            {
-                DateTimePrecision.Year => Year,
-                DateTimePrecision.Month => Month,
-                DateTimePrecision.Day => Day,
-                DateTimePrecision.Hour => Hour,
-                DateTimePrecision.Minute => Minute,
-                DateTimePrecision.Second => Second,
-                DateTimePrecision.Millisecond => Millisecond,
-                _ => null,
-            };
-        }
     }
 
 

--- a/Cql/Cql.Abstractions/UCUMUnits.cs
+++ b/Cql/Cql.Abstractions/UCUMUnits.cs
@@ -7,6 +7,7 @@
  */
 
 using Hl7.Cql.Iso8601;
+using System.Collections.Generic;
 
 namespace Hl7.Cql.Abstractions
 {
@@ -79,6 +80,13 @@ namespace Hl7.Cql.Abstractions
         /// Centimeters
         /// </summary>
         public const string Centimeter = "cm";
+        /// <summary>
+        /// List of UCUM units commonly used for date and time intervals.
+        /// </summary>
+        public static readonly List<string> DateTimeUnits = new List<string>
+        {
+            Year, Month, Day, Hour, Minute, Second, Millisecond
+        };
     }
 
 

--- a/Cql/Cql.Abstractions/Units.cs
+++ b/Cql/Cql.Abstractions/Units.cs
@@ -20,70 +20,24 @@ namespace Hl7.Cql.Abstractions
         /// Maps CQL unit keywords (singular or plural) to their corresponding UCUM unit codes.
         /// </summary>
         /// <see href="https://www.hl7.org/fhir/valueset-ucum-units.html"/>
-        public static readonly IDictionary<string, string> CqlUnitsToUCUM = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            { "year",           UCUMUnits.Year },
-            { "years",          UCUMUnits.Year },
-            { "month",          UCUMUnits.Month },
-            { "months",         UCUMUnits.Month },
-            { "days",           UCUMUnits.Day },
-            { "day",            UCUMUnits.Day },
-            { "week",           UCUMUnits.Week },
-            { "weeks",          UCUMUnits.Week },
-            { "hour",           UCUMUnits.Hour },
-            { "hours",          UCUMUnits.Hour },
-            { "minute",         UCUMUnits.Minute },
-            { "minutes",        UCUMUnits.Minute },
-            { "second",         UCUMUnits.Second },
-            { "seconds",        UCUMUnits.Second },
-            { "millisecond",    UCUMUnits.Millisecond },
-            { "milliseconds",   UCUMUnits.Millisecond },
-        };
-
-        /// <summary>
-        /// Maps UCUM unit codes to their corresponding CQL keywords, singular.
-        /// </summary>
-        public static readonly IDictionary<string, string> UCUMUnitsToCql = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            { UCUMUnits.Year,           "year" },
-            { UCUMUnits.Month,          "month" },
-            { UCUMUnits.Week,           "week" },
-            { UCUMUnits.Day,            "day" },
-            { UCUMUnits.Hour,           "hour" },
-            { UCUMUnits.Minute,         "minute" },
-            { UCUMUnits.Second,         "second" },
-            { UCUMUnits.Millisecond,    "millisecond" },
-        };
-
-        /// <summary>
-        /// Maps CQL unit keywords (singular or plural) to their corresponding UCUM unit codes.
-        /// </summary>
-        /// <see href="https://www.hl7.org/fhir/valueset-ucum-units.html"/>
         public static readonly IDictionary<string, string> DatePrecisionToCqlUnits = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             { "Year",           "year" },
-            { "Years",          "years" },
             { "Month",          "month" },
-            { "Months",         "months" },
             { "Day",            "day" },
-            { "Days",           "days" },
             { "Week",           "week" },
-            { "Weeks",          "weeks" },
             { "Hour",           "hour" },
-            { "Hours",          "hours" },
             { "Minute",         "minute" },
-            { "Minutes",        "minutes" },
             { "Second",         "second" },
-            { "Seconds",        "seconds" },
-            { "Millisecond",    "millisecond" },
-            { "Milliseconds",   "milliseconds" },
+            { "Millisecond",    "millisecond" }
         };
+        
 
         /// <summary>
         /// Maps CQL unit keywords (singular or plural) to their corresponding UCUM unit codes.
         /// </summary>
         /// <see href="https://www.hl7.org/fhir/valueset-ucum-units.html"/>
-        public static readonly List<string> cqlDateTimeUnits = new List<string>
+        public static readonly List<string> CqlDateTimeUnits = new List<string>
         {
             "year", "years", "month", "months", "days", "day", "week", "weeks", "hour", "hours", "minute", "minutes", "second", "seconds", "millisecond", "milliseconds"
         };

--- a/Cql/Cql.Abstractions/Units.cs
+++ b/Cql/Cql.Abstractions/Units.cs
@@ -12,12 +12,12 @@ using System.Collections.Generic;
 namespace Hl7.Cql.Abstractions
 {
     /// <summary>
-    /// Utilities for converting between CQL and UCUM units.
+    /// Utilities for converting precision to cql units
     /// </summary>
     public static class Units
     {
         /// <summary>
-        /// Maps CQL unit keywords (singular or plural) to their corresponding UCUM unit codes.
+        /// Maps DateTime Precisions to their corresponding CQL units.
         /// </summary>
         /// <see href="https://www.hl7.org/fhir/valueset-ucum-units.html"/>
         public static readonly IDictionary<string, string> DatePrecisionToCqlUnits = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -30,16 +30,6 @@ namespace Hl7.Cql.Abstractions
             { "Minute",         "minute" },
             { "Second",         "second" },
             { "Millisecond",    "millisecond" }
-        };
-        
-
-        /// <summary>
-        /// Maps CQL unit keywords (singular or plural) to their corresponding UCUM unit codes.
-        /// </summary>
-        /// <see href="https://www.hl7.org/fhir/valueset-ucum-units.html"/>
-        public static readonly List<string> CqlDateTimeUnits = new List<string>
-        {
-            "year", "years", "month", "months", "days", "day", "week", "weeks", "hour", "hours", "minute", "minutes", "second", "seconds", "millisecond", "milliseconds"
         };
 
     }

--- a/Cql/Cql.Abstractions/Units.cs
+++ b/Cql/Cql.Abstractions/Units.cs
@@ -19,7 +19,6 @@ namespace Hl7.Cql.Abstractions
         /// <summary>
         /// Maps DateTime Precisions to their corresponding CQL units.
         /// </summary>
-        /// <see href="https://www.hl7.org/fhir/valueset-ucum-units.html"/>
         public static readonly IDictionary<string, string> DatePrecisionToCqlUnits = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             { "Year",           "year" },

--- a/Cql/Cql.Abstractions/Units.cs
+++ b/Cql/Cql.Abstractions/Units.cs
@@ -55,5 +55,38 @@ namespace Hl7.Cql.Abstractions
             { UCUMUnits.Millisecond,    "millisecond" },
         };
 
+        /// <summary>
+        /// Maps CQL unit keywords (singular or plural) to their corresponding UCUM unit codes.
+        /// </summary>
+        /// <see href="https://www.hl7.org/fhir/valueset-ucum-units.html"/>
+        public static readonly IDictionary<string, string> DatePrecisionToCqlUnits = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "Year",           "year" },
+            { "Years",          "years" },
+            { "Month",          "month" },
+            { "Months",         "months" },
+            { "Day",            "day" },
+            { "Days",           "days" },
+            { "Week",           "week" },
+            { "Weeks",          "weeks" },
+            { "Hour",           "hour" },
+            { "Hours",          "hours" },
+            { "Minute",         "minute" },
+            { "Minutes",        "minutes" },
+            { "Second",         "second" },
+            { "Seconds",        "seconds" },
+            { "Millisecond",    "millisecond" },
+            { "Milliseconds",   "milliseconds" },
+        };
+
+        /// <summary>
+        /// Maps CQL unit keywords (singular or plural) to their corresponding UCUM unit codes.
+        /// </summary>
+        /// <see href="https://www.hl7.org/fhir/valueset-ucum-units.html"/>
+        public static readonly List<string> cqlDateTimeUnits = new List<string>
+        {
+            "year", "years", "month", "months", "days", "day", "week", "weeks", "hour", "hours", "minute", "minutes", "second", "seconds", "millisecond", "milliseconds"
+        };
+
     }
 }

--- a/Cql/Cql.Comparers/CqlQuantityCqlComparer.cs
+++ b/Cql/Cql.Comparers/CqlQuantityCqlComparer.cs
@@ -15,7 +15,7 @@ using System;
 namespace Hl7.Cql.Comparers
 {
     /// <summary>
-    /// A comparer that compares to <see cref="CqlQuantity"/> instances, possibly by normalizing their values 
+    /// A comparer that compares two <see cref="CqlQuantity"/> instances, possibly by normalizing their values 
     /// using the UCUM system.
     /// </summary>
     internal class CqlQuantityCqlComparer : ICqlComparer<CqlQuantity>, ICqlComparer

--- a/Cql/Cql.Conversion/UcumConversionExtensions.cs
+++ b/Cql/Cql.Conversion/UcumConversionExtensions.cs
@@ -13,7 +13,7 @@ using M = Fhir.Metrics;
 namespace Hl7.Cql.Conversion
 {
     /// <summary>
-    /// Utility functions for working with Fireky's UCUM library, which allows full support for conversions within the UCUM unit system.
+    /// Utility functions for working with Firely's UCUM library, which allows full support for conversions within the UCUM unit system.
     /// </summary>
     internal static class Ucum
     {

--- a/Cql/Cql.Conversion/UnitConverter.cs
+++ b/Cql/Cql.Conversion/UnitConverter.cs
@@ -118,40 +118,35 @@ namespace Hl7.Cql.Conversion
         {
             var year = new Dictionary<string, Func<decimal, decimal>>
             {
-                {  UCUMUnits.Day, (decimal value) => value * ConversionConstants.DaysPerYear },
-                {  UCUMUnits.Month, (decimal value) => value / 12m },
-                {  UCUMUnits.Week, (decimal value) => (value* ConversionConstants.DaysPerYear) * 0.14285714285m /* 1/7 */ },
-                {  UCUMUnits.Year, (decimal value) => value },
+                {  "day", (decimal value) => value * ConversionConstants.DaysPerYear },
+                {  "month", (decimal value) => value / 12m },
+                {  "week", (decimal value) => (value* ConversionConstants.DaysPerYear) * 0.14285714285m /* 1/7 */ }
             };
             Conversions.Add("year", year);
 
             var month = new Dictionary<string, Func<decimal, decimal>>
             {
-                {  UCUMUnits.Day, (decimal value) => value * ConversionConstants.DaysPerMonth },
-                {  UCUMUnits.Year, (decimal value) => value * 12m },
-                {  UCUMUnits.Week, (decimal value) => (value * ConversionConstants.DaysPerMonth) * 0.14285714285m /* 1/7 */ },
-                {  UCUMUnits.Month, (decimal value) => value },
+                {  "day", (decimal value) => value * ConversionConstants.DaysPerMonth },
+                {  "year", (decimal value) => value * 12m },
+                {  "week", (decimal value) => (value * ConversionConstants.DaysPerMonth) * 0.14285714285m /* 1/7 */ }
             };
             Conversions.Add("month", month);
 
             var day = new Dictionary<string, Func<decimal, decimal>>
             {
-                {  UCUMUnits.Month, (decimal value) => value * ConversionConstants.MonthsPerDay },
-                {  UCUMUnits.Year, (decimal value) => value * ConversionConstants.YearsPerDay },
-                {  UCUMUnits.Week, (decimal value) => value * 0.14285714285m /* 1/7 */ },
-                {  UCUMUnits.Day, (decimal value) => value },
+                {  "month", (decimal value) => value * ConversionConstants.MonthsPerDay },
+                {  "year", (decimal value) => value * ConversionConstants.YearsPerDay },
+                {  "week", (decimal value) => value * 0.14285714285m /* 1/7 */ }
             };
             Conversions.Add("day", day);
 
             var week = new Dictionary<string, Func<decimal, decimal>>
             {
-                {  UCUMUnits.Day, (decimal value) => value * 7m },
-                {  UCUMUnits.Month, (decimal value) => value * 7m * ConversionConstants.MonthsPerDay },
-                {  UCUMUnits.Year, (decimal value) => value * 7m * ConversionConstants.YearsPerDay },
-                {  UCUMUnits.Week, (decimal value) => value },
+                {  "day", (decimal value) => value * 7m },
+                {  "month", (decimal value) => value * 7m * ConversionConstants.MonthsPerDay },
+                {  "year", (decimal value) => value * 7m * ConversionConstants.YearsPerDay }
             };
             Conversions.Add("week", week);
-
         }
 
         private void InitializeLengthUnits()

--- a/Cql/Cql.Conversion/UnitConverter.cs
+++ b/Cql/Cql.Conversion/UnitConverter.cs
@@ -99,8 +99,6 @@ namespace Hl7.Cql.Conversion
                 return null;
 
             string fromUnit = source.unit ?? "1";
-/*            if (Units.CqlUnitsToUCUM.TryGetValue(fromUnit, out var ucumUnit))
-                fromUnit = ucumUnit;*/
 
             var newValue = ChangeUnits(source.value.Value, fromUnit, ucumUnits);
             var newQuanitty = new CqlQuantity(newValue, ucumUnits);
@@ -112,17 +110,17 @@ namespace Hl7.Cql.Conversion
         /// </summary>
         public UnitConverter()
         {
-            InitialzeDateConversions();
+            //InitialzeDateConversions();
             InitializeLengthUnits();
         }
 
-        private void InitialzeDateConversions()
+/*        private void InitialzeDateConversions()
         {
             var year = new Dictionary<string, Func<decimal, decimal>>
             {
                 {  UCUMUnits.Day, (decimal value) => value * ConversionConstants.DaysPerYear },
                 {  UCUMUnits.Month, (decimal value) => value / 12m },
-                {  UCUMUnits.Week, (decimal value) => (value* ConversionConstants.DaysPerYear) * 0.14285714285m /* 1/7 */ },
+                {  UCUMUnits.Week, (decimal value) => (value* ConversionConstants.DaysPerYear) * 0.14285714285m *//* 1/7 *//* },
             };
             Conversions.Add(UCUMUnits.Year, year);
 
@@ -130,7 +128,7 @@ namespace Hl7.Cql.Conversion
             {
                 {  UCUMUnits.Day, (decimal value) => value * ConversionConstants.DaysPerMonth },
                 {  UCUMUnits.Year, (decimal value) => value * 12m },
-                {  UCUMUnits.Week, (decimal value) => (value * ConversionConstants.DaysPerMonth) * 0.14285714285m /* 1/7 */ },
+                {  UCUMUnits.Week, (decimal value) => (value * ConversionConstants.DaysPerMonth) * 0.14285714285m *//* 1/7 *//* },
             };
             Conversions.Add(UCUMUnits.Month, month);
 
@@ -138,7 +136,7 @@ namespace Hl7.Cql.Conversion
             {
                 {  UCUMUnits.Month, (decimal value) => value * ConversionConstants.MonthsPerDay },
                 {  UCUMUnits.Year, (decimal value) => value * ConversionConstants.YearsPerDay },
-                {  UCUMUnits.Week, (decimal value) => value * 0.14285714285m /* 1/7 */ },
+                {  UCUMUnits.Week, (decimal value) => value * 0.14285714285m *//* 1/7 *//* },
             };
             Conversions.Add(UCUMUnits.Day, day);
 
@@ -150,7 +148,7 @@ namespace Hl7.Cql.Conversion
             };
             Conversions.Add(UCUMUnits.Week, week);
 
-        }
+        }*/
         private void InitializeLengthUnits()
         {
             var inches = new Dictionary<string, Func<decimal, decimal>>

--- a/Cql/Cql.Conversion/UnitConverter.cs
+++ b/Cql/Cql.Conversion/UnitConverter.cs
@@ -110,45 +110,9 @@ namespace Hl7.Cql.Conversion
         /// </summary>
         public UnitConverter()
         {
-            //InitialzeDateConversions();
             InitializeLengthUnits();
         }
 
-/*        private void InitialzeDateConversions()
-        {
-            var year = new Dictionary<string, Func<decimal, decimal>>
-            {
-                {  UCUMUnits.Day, (decimal value) => value * ConversionConstants.DaysPerYear },
-                {  UCUMUnits.Month, (decimal value) => value / 12m },
-                {  UCUMUnits.Week, (decimal value) => (value* ConversionConstants.DaysPerYear) * 0.14285714285m *//* 1/7 *//* },
-            };
-            Conversions.Add(UCUMUnits.Year, year);
-
-            var month = new Dictionary<string, Func<decimal, decimal>>
-            {
-                {  UCUMUnits.Day, (decimal value) => value * ConversionConstants.DaysPerMonth },
-                {  UCUMUnits.Year, (decimal value) => value * 12m },
-                {  UCUMUnits.Week, (decimal value) => (value * ConversionConstants.DaysPerMonth) * 0.14285714285m *//* 1/7 *//* },
-            };
-            Conversions.Add(UCUMUnits.Month, month);
-
-            var day = new Dictionary<string, Func<decimal, decimal>>
-            {
-                {  UCUMUnits.Month, (decimal value) => value * ConversionConstants.MonthsPerDay },
-                {  UCUMUnits.Year, (decimal value) => value * ConversionConstants.YearsPerDay },
-                {  UCUMUnits.Week, (decimal value) => value * 0.14285714285m *//* 1/7 *//* },
-            };
-            Conversions.Add(UCUMUnits.Day, day);
-
-            var week = new Dictionary<string, Func<decimal, decimal>>
-            {
-                {  UCUMUnits.Day, (decimal value) => value * 7m },
-                {  UCUMUnits.Month, (decimal value) => value * 7m * ConversionConstants.MonthsPerDay },
-                {  UCUMUnits.Year, (decimal value) => value * 7m * ConversionConstants.YearsPerDay },
-            };
-            Conversions.Add(UCUMUnits.Week, week);
-
-        }*/
         private void InitializeLengthUnits()
         {
             var inches = new Dictionary<string, Func<decimal, decimal>>

--- a/Cql/Cql.Conversion/UnitConverter.cs
+++ b/Cql/Cql.Conversion/UnitConverter.cs
@@ -101,8 +101,8 @@ namespace Hl7.Cql.Conversion
             string fromUnit = source.unit ?? "1";
 
             var newValue = ChangeUnits(source.value.Value, fromUnit, ucumUnits);
-            var newQuanitty = new CqlQuantity(newValue, ucumUnits);
-            return newQuanitty;
+            var newQuantity = new CqlQuantity(newValue, ucumUnits);
+            return newQuantity;
         }
 
         /// <summary>
@@ -110,7 +110,48 @@ namespace Hl7.Cql.Conversion
         /// </summary>
         public UnitConverter()
         {
+            InitialzeDateConversions();
             InitializeLengthUnits();
+        }
+
+        private void InitialzeDateConversions()
+        {
+            var year = new Dictionary<string, Func<decimal, decimal>>
+            {
+                {  UCUMUnits.Day, (decimal value) => value * ConversionConstants.DaysPerYear },
+                {  UCUMUnits.Month, (decimal value) => value / 12m },
+                {  UCUMUnits.Week, (decimal value) => (value* ConversionConstants.DaysPerYear) * 0.14285714285m /* 1/7 */ },
+                {  UCUMUnits.Year, (decimal value) => value },
+            };
+            Conversions.Add("year", year);
+
+            var month = new Dictionary<string, Func<decimal, decimal>>
+            {
+                {  UCUMUnits.Day, (decimal value) => value * ConversionConstants.DaysPerMonth },
+                {  UCUMUnits.Year, (decimal value) => value * 12m },
+                {  UCUMUnits.Week, (decimal value) => (value * ConversionConstants.DaysPerMonth) * 0.14285714285m /* 1/7 */ },
+                {  UCUMUnits.Month, (decimal value) => value },
+            };
+            Conversions.Add("month", month);
+
+            var day = new Dictionary<string, Func<decimal, decimal>>
+            {
+                {  UCUMUnits.Month, (decimal value) => value * ConversionConstants.MonthsPerDay },
+                {  UCUMUnits.Year, (decimal value) => value * ConversionConstants.YearsPerDay },
+                {  UCUMUnits.Week, (decimal value) => value * 0.14285714285m /* 1/7 */ },
+                {  UCUMUnits.Day, (decimal value) => value },
+            };
+            Conversions.Add("day", day);
+
+            var week = new Dictionary<string, Func<decimal, decimal>>
+            {
+                {  UCUMUnits.Day, (decimal value) => value * 7m },
+                {  UCUMUnits.Month, (decimal value) => value * 7m * ConversionConstants.MonthsPerDay },
+                {  UCUMUnits.Year, (decimal value) => value * 7m * ConversionConstants.YearsPerDay },
+                {  UCUMUnits.Week, (decimal value) => value },
+            };
+            Conversions.Add("week", week);
+
         }
 
         private void InitializeLengthUnits()

--- a/Cql/Cql.Conversion/UnitConverter.cs
+++ b/Cql/Cql.Conversion/UnitConverter.cs
@@ -99,8 +99,8 @@ namespace Hl7.Cql.Conversion
                 return null;
 
             string fromUnit = source.unit ?? "1";
-            if (Units.CqlUnitsToUCUM.TryGetValue(fromUnit, out var ucumUnit))
-                fromUnit = ucumUnit;
+/*            if (Units.CqlUnitsToUCUM.TryGetValue(fromUnit, out var ucumUnit))
+                fromUnit = ucumUnit;*/
 
             var newValue = ChangeUnits(source.value.Value, fromUnit, ucumUnits);
             var newQuanitty = new CqlQuantity(newValue, ucumUnits);

--- a/Cql/Cql.Operators/CqlOperators.ArithmeticOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ArithmeticOperators.cs
@@ -80,8 +80,19 @@ namespace Hl7.Cql.Runtime
             else if (left.value == null || right.value == null)
                 return null;
             else if (left.unit != right.unit)
-                throw new NotSupportedException("Mixed unit arithmetic is not supported.");
-            else return new CqlQuantity(Add(left.value, right.value), left.unit);
+            {
+                string? leftUnit = left.unit;
+                string? rightUnit = right.unit;
+                string normalizedLeftUnit = !string.IsNullOrEmpty(leftUnit) && leftUnit.EndsWith("s") ? leftUnit.Substring(0, leftUnit.Length - 1) : leftUnit ?? string.Empty;
+                string normalizedRightUnit = !string.IsNullOrEmpty(rightUnit) && rightUnit.EndsWith("s") ? rightUnit.Substring(0, rightUnit.Length - 1) : rightUnit ?? string.Empty;
+
+                if (normalizedLeftUnit != normalizedRightUnit)
+                    throw new NotSupportedException("Mixed unit arithmetic is not supported.");
+                // If normalized units are equal, proceed
+                return new CqlQuantity(Add(left.value, right.value), left.unit);
+            }   
+            else 
+                return new CqlQuantity(Add(left.value, right.value), left.unit);
         }
 
         #endregion
@@ -448,7 +459,17 @@ namespace Hl7.Cql.Runtime
             else if (left.value == null || right.value == null)
                 return null;
             else if (left.unit != right.unit)
-                throw new NotSupportedException("Mixed unit arithmetic is not supported.");
+            {
+                string? leftUnit = left.unit;
+                string? rightUnit = right.unit;
+                string normalizedLeftUnit = !string.IsNullOrEmpty(leftUnit) && leftUnit.EndsWith("s") ? leftUnit.Substring(0, leftUnit.Length - 1) : leftUnit ?? string.Empty;
+                string normalizedRightUnit = !string.IsNullOrEmpty(rightUnit) && rightUnit.EndsWith("s") ? rightUnit.Substring(0, rightUnit.Length - 1) : rightUnit ?? string.Empty;
+
+                if (normalizedLeftUnit != normalizedRightUnit)
+                    throw new NotSupportedException("Mixed unit arithmetic is not supported.");
+                // If normalized units are equal, proceed
+                return new CqlQuantity(Modulo(left.value, right.value), left.unit);
+            }
             else
                 return new CqlQuantity(Modulo(left.value, right.value), left.unit);
         }
@@ -703,8 +724,19 @@ namespace Hl7.Cql.Runtime
             else if (left.value == null || right.value == null)
                 return null;
             else if (left.unit != right.unit)
-                throw new NotSupportedException("Mixed unit arithmetic is not supported.");
-            else return new CqlQuantity(Subtract(left.value, right.value), left.unit);
+            {
+                string? leftUnit = left.unit;
+                string? rightUnit = right.unit;
+                string normalizedLeftUnit = !string.IsNullOrEmpty(leftUnit) && leftUnit.EndsWith("s") ? leftUnit.Substring(0, leftUnit.Length - 1) : leftUnit ?? string.Empty;
+                string normalizedRightUnit = !string.IsNullOrEmpty(rightUnit) && rightUnit.EndsWith("s") ? rightUnit.Substring(0, rightUnit.Length - 1) : rightUnit ?? string.Empty;
+
+                if (normalizedLeftUnit != normalizedRightUnit)
+                    throw new NotSupportedException("Mixed unit arithmetic is not supported.");
+                // If normalized units are equal, proceed
+                return new CqlQuantity(Subtract(left.value, right.value), left.unit);
+            }
+            else
+                return new CqlQuantity(Subtract(left.value, right.value), left.unit);
         }
 
         #endregion

--- a/Cql/Cql.Operators/CqlOperators.DateTimeOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.DateTimeOperators.cs
@@ -359,8 +359,6 @@ namespace Hl7.Cql.Runtime
 
         protected bool GreaterOrSamePrecision(DateTimePrecision left, string precision)
         {
-/*            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var ucum))
-                precision = ucum;*/
             var right = precision.ToDateTimePrecision();
             if (right == null || right == DateTimePrecision.Unknown)
                 throw new ArgumentException($"Unknown precision {precision}", nameof(precision));

--- a/Cql/Cql.Operators/CqlOperators.DateTimeOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.DateTimeOperators.cs
@@ -359,8 +359,8 @@ namespace Hl7.Cql.Runtime
 
         protected bool GreaterOrSamePrecision(DateTimePrecision left, string precision)
         {
-            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var ucum))
-                precision = ucum;
+/*            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var ucum))
+                precision = ucum;*/
             var right = precision.ToDateTimePrecision();
             if (right == null || right == DateTimePrecision.Unknown)
                 throw new ArgumentException($"Unknown precision {precision}", nameof(precision));

--- a/Cql/Cql.Operators/CqlOperators.IntervalOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.IntervalOperators.cs
@@ -671,20 +671,26 @@ namespace Hl7.Cql.Runtime
             {
                 if (interval.low!.Precision == interval.high!.Precision)
                 {
-                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                    per = new CqlQuantity(1, ucmunits);
+                    /*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
+                                        per = new CqlQuantity(1, ucmunits);*/
+                    Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits); 
+                    per = new CqlQuantity(1, cqlunits);
                 }
                 else if (interval.low.Precision < interval.high.Precision)
                 {
-                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                    per = new CqlQuantity(1, ucmunits);
+                    /*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
+                                        per = new CqlQuantity(1, ucmunits);*/
+                    Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
+                    per = new CqlQuantity(1, cqlunits);
 
                     setHighPrecisionToPer = true;
                 }
                 else
                 {
-                    Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
-                    per = new CqlQuantity(1, ucmunits);
+                    /*                    Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
+                                        per = new CqlQuantity(1, ucmunits);*/
+                    Units.DatePrecisionToCqlUnits.TryGetValue(interval.high.Precision.ToString(), out var cqlunits);
+                    per = new CqlQuantity(1, cqlunits);
 
                     setLowPrecisionToPer = true;
                 }
@@ -693,7 +699,8 @@ namespace Hl7.Cql.Runtime
             {
                 switch (per.unit)
                 {
-                    case "mo":
+                    case "month":
+                    case "months":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Month
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Month)
                             return expanded;
@@ -705,8 +712,10 @@ namespace Hl7.Cql.Runtime
 
 
                         break;
-                    case "d":
-                    case "wk":
+                    case "day":
+                    case "days":
+                    case "week":
+                    case "weeks":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Day
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Day)
                             return expanded;
@@ -719,10 +728,16 @@ namespace Hl7.Cql.Runtime
                         break;
                     // parsed as a time unit when it's a date so default to the coarsest
                     // ex: Interval[2023-01-01, 2023-12-31] per minute
-                    case "h":
-                    case "min":
-                    case "s":
-                    case "ms":
+
+                    
+                    case "hour":
+                    case "hours":
+                    case "minute":
+                    case "minutes":
+                    case "second":
+                    case "seconds":
+                    case "millisecond":
+                    case "milliseconds":
                         return expanded;
                 }
             }
@@ -797,20 +812,23 @@ namespace Hl7.Cql.Runtime
             {
                 if (interval.low!.Precision == interval.high!.Precision)
                 {
-                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                    per = new CqlQuantity(1, ucmunits);
+/*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
+                    per = new CqlQuantity(1, ucmunits);*/
+                    per = new CqlQuantity(1, interval.low.Precision.ToString());
                 }
                 else if (interval.low.Precision < interval.high.Precision)
                 {
-                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                    per = new CqlQuantity(1, ucmunits);
+/*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
+                    per = new CqlQuantity(1, ucmunits);*/
+                    per = new CqlQuantity(1, interval.low.Precision.ToString());
 
                     setHighPrecisionToPer = true;
                 }
                 else
                 {
-                    Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
-                    per = new CqlQuantity(1, ucmunits);
+/*                    Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
+                    per = new CqlQuantity(1, ucmunits);*/
+                    per = new CqlQuantity(1, interval.high.Precision.ToString());
 
                     setLowPrecisionToPer = true;
                 }
@@ -819,7 +837,8 @@ namespace Hl7.Cql.Runtime
             {
                 switch (per.unit)
                 {
-                    case "mo":
+                    case "month":
+                    case "months":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Month
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Month)
                             return expanded;
@@ -830,8 +849,10 @@ namespace Hl7.Cql.Runtime
                             setHighPrecisionToPer = true;
 
                         break;
-                    case "d":
-                    case "wk":
+                    case "day":
+                    case "days":
+                    case "week":
+                    case "weeks":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Day
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Day)
                             return expanded;
@@ -843,7 +864,8 @@ namespace Hl7.Cql.Runtime
 
                         break;
                     // per has a coarser precision than the interval so nothing is added
-                    case "h":
+                    case "hour":
+                    case "hours":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Hour
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Hour)
                             return expanded;
@@ -854,7 +876,8 @@ namespace Hl7.Cql.Runtime
                             setHighPrecisionToPer = true;
 
                         break;
-                    case "min":
+                    case "minute":
+                    case "minutes":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Minute
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Minute)
                             return expanded;
@@ -865,7 +888,8 @@ namespace Hl7.Cql.Runtime
                             setHighPrecisionToPer = true;
 
                         break;
-                    case "s":
+                    case "second":
+                    case "seconds":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Second
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Second)
                             return expanded;
@@ -972,20 +996,23 @@ namespace Hl7.Cql.Runtime
             {
                 if (interval.low!.Precision == interval.high!.Precision)
                 {
-                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                    per = new CqlQuantity(1, ucmunits);
+/*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
+                    per = new CqlQuantity(1, ucmunits);*/
+                    per = new CqlQuantity(1, interval.low.Precision.ToString());
                 }
                 else if (interval.low.Precision < interval.high.Precision)
                 {
-                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                    per = new CqlQuantity(1, ucmunits);
+/*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
+                    per = new CqlQuantity(1, ucmunits);*/
+                    per = new CqlQuantity(1, interval.low.Precision.ToString());
 
                     setHighPrecisionToPer = true;
                 }
                 else
                 {
-                    Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
-                    per = new CqlQuantity(1, ucmunits);
+/*                    Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
+                    per = new CqlQuantity(1, ucmunits);*/
+                    per = new CqlQuantity(1, interval.high.Precision.ToString());
 
                     setLowPrecisionToPer = true;
                 }
@@ -995,7 +1022,8 @@ namespace Hl7.Cql.Runtime
                 switch (per.unit)
                 {
                     // per has a coarser precision than the interval so nothing is added
-                    case "h":
+                    case "hour":
+                    case "hours":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Hour
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Hour)
                             return expanded;
@@ -1006,7 +1034,8 @@ namespace Hl7.Cql.Runtime
                             setHighPrecisionToPer = true;
 
                         break;
-                    case "min":
+                    case "minute":
+                    case "minutes":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Minute
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Minute)
                             return expanded;
@@ -1017,7 +1046,8 @@ namespace Hl7.Cql.Runtime
                             setHighPrecisionToPer = true;
 
                         break;
-                    case "s":
+                    case "second":
+                    case "seconds":
                         if (interval.low!.Precision > Iso8601.DateTimePrecision.Second
                             && interval.high!.Precision > Iso8601.DateTimePrecision.Second)
                             return expanded;
@@ -1030,10 +1060,14 @@ namespace Hl7.Cql.Runtime
                         break;
                     // parsed as a date unit when it's a time so return empty list
                     // ex: Interval[@T10, @T10] per month
-                    case "a":
-                    case "mo":
-                    case "d":
-                    case "wk":
+                    case "year":
+                    case "years":
+                    case "month":
+                    case "months":
+                    case "day":
+                    case "days":
+                    case "week":
+                    case "weeks":
                         return expanded;
                 }
             }
@@ -1110,8 +1144,10 @@ namespace Hl7.Cql.Runtime
                 per = new CqlQuantity(1, "1");
             else
             {
-                Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
+/*                Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
                 if (ucumUnits != null)
+                    return expanded;*/
+                if (per.unit is not null && Units.cqlDateTimeUnits.Contains(per.unit))
                     return expanded;
             }
 
@@ -1146,8 +1182,10 @@ namespace Hl7.Cql.Runtime
                 per = new CqlQuantity(1, "1");
             else
             {
-                Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
+/*                Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
                 if (ucumUnits != null)
+                    return expanded;*/
+                if (per.unit is not null && Units.cqlDateTimeUnits.Contains(per.unit))
                     return expanded;
             }
 
@@ -1184,8 +1222,10 @@ namespace Hl7.Cql.Runtime
                 per = new CqlQuantity(1, "1");
             else
             {
-                Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
-                if (ucumUnits != null)
+                /*                Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
+                                if (ucumUnits != null)
+                                    return expanded;*/
+                if (per.unit is not null && Units.cqlDateTimeUnits.Contains(per.unit))
                     return expanded;
             }
 

--- a/Cql/Cql.Operators/CqlOperators.IntervalOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.IntervalOperators.cs
@@ -360,6 +360,9 @@ namespace Hl7.Cql.Runtime
             {
                 if (x == null || y == null) return null;
 
+                var x1 = meets(x, y, precision);
+                var x2 = OverlapsHelper(x, y, precision, toClosed);
+
                 // From spec language:
                 // In other words, adjacent intervals within a sorted list are merged if they either overlap or meet.
                 if ((meets(x, y, precision) ?? false) || (OverlapsHelper(x, y, precision, toClosed) ?? false))

--- a/Cql/Cql.Operators/CqlOperators.IntervalOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.IntervalOperators.cs
@@ -814,13 +814,15 @@ namespace Hl7.Cql.Runtime
                 {
 /*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
                     per = new CqlQuantity(1, ucmunits);*/
-                    per = new CqlQuantity(1, interval.low.Precision.ToString());
+                    Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
+                    per = new CqlQuantity(1, cqlunits);
                 }
                 else if (interval.low.Precision < interval.high.Precision)
                 {
-/*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                    per = new CqlQuantity(1, ucmunits);*/
-                    per = new CqlQuantity(1, interval.low.Precision.ToString());
+                    /*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
+                                        per = new CqlQuantity(1, ucmunits);*/
+                    Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
+                    per = new CqlQuantity(1, cqlunits);
 
                     setHighPrecisionToPer = true;
                 }
@@ -828,7 +830,8 @@ namespace Hl7.Cql.Runtime
                 {
 /*                    Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
                     per = new CqlQuantity(1, ucmunits);*/
-                    per = new CqlQuantity(1, interval.high.Precision.ToString());
+                    Units.DatePrecisionToCqlUnits.TryGetValue(interval.high.Precision.ToString(), out var cqlunits);
+                    per = new CqlQuantity(1, cqlunits);
 
                     setLowPrecisionToPer = true;
                 }

--- a/Cql/Cql.Operators/CqlOperators.IntervalOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.IntervalOperators.cs
@@ -674,15 +674,11 @@ namespace Hl7.Cql.Runtime
             {
                 if (interval.low!.Precision == interval.high!.Precision)
                 {
-                    /*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                                        per = new CqlQuantity(1, ucmunits);*/
                     Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits); 
                     per = new CqlQuantity(1, cqlunits);
                 }
                 else if (interval.low.Precision < interval.high.Precision)
                 {
-                    /*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                                        per = new CqlQuantity(1, ucmunits);*/
                     Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
                     per = new CqlQuantity(1, cqlunits);
 
@@ -690,8 +686,6 @@ namespace Hl7.Cql.Runtime
                 }
                 else
                 {
-                    /*                    Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
-                                        per = new CqlQuantity(1, ucmunits);*/
                     Units.DatePrecisionToCqlUnits.TryGetValue(interval.high.Precision.ToString(), out var cqlunits);
                     per = new CqlQuantity(1, cqlunits);
 
@@ -703,7 +697,6 @@ namespace Hl7.Cql.Runtime
                 switch (per.unit)
                 {
                     case "month":
-                    case "months":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Month
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Month)
                             return expanded;
@@ -716,9 +709,7 @@ namespace Hl7.Cql.Runtime
 
                         break;
                     case "day":
-                    case "days":
                     case "week":
-                    case "weeks":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Day
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Day)
                             return expanded;
@@ -734,13 +725,9 @@ namespace Hl7.Cql.Runtime
 
                     
                     case "hour":
-                    case "hours":
                     case "minute":
-                    case "minutes":
                     case "second":
-                    case "seconds":
                     case "millisecond":
-                    case "milliseconds":
                         return expanded;
                 }
             }
@@ -815,15 +802,11 @@ namespace Hl7.Cql.Runtime
             {
                 if (interval.low!.Precision == interval.high!.Precision)
                 {
-/*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                    per = new CqlQuantity(1, ucmunits);*/
                     Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
                     per = new CqlQuantity(1, cqlunits);
                 }
                 else if (interval.low.Precision < interval.high.Precision)
                 {
-                    /*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                                        per = new CqlQuantity(1, ucmunits);*/
                     Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
                     per = new CqlQuantity(1, cqlunits);
 
@@ -831,8 +814,6 @@ namespace Hl7.Cql.Runtime
                 }
                 else
                 {
-/*                    Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
-                    per = new CqlQuantity(1, ucmunits);*/
                     Units.DatePrecisionToCqlUnits.TryGetValue(interval.high.Precision.ToString(), out var cqlunits);
                     per = new CqlQuantity(1, cqlunits);
 
@@ -844,7 +825,6 @@ namespace Hl7.Cql.Runtime
                 switch (per.unit)
                 {
                     case "month":
-                    case "months":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Month
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Month)
                             return expanded;
@@ -856,9 +836,7 @@ namespace Hl7.Cql.Runtime
 
                         break;
                     case "day":
-                    case "days":
                     case "week":
-                    case "weeks":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Day
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Day)
                             return expanded;
@@ -871,7 +849,6 @@ namespace Hl7.Cql.Runtime
                         break;
                     // per has a coarser precision than the interval so nothing is added
                     case "hour":
-                    case "hours":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Hour
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Hour)
                             return expanded;
@@ -883,7 +860,6 @@ namespace Hl7.Cql.Runtime
 
                         break;
                     case "minute":
-                    case "minutes":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Minute
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Minute)
                             return expanded;
@@ -895,7 +871,6 @@ namespace Hl7.Cql.Runtime
 
                         break;
                     case "second":
-                    case "seconds":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Second
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Second)
                             return expanded;
@@ -1002,15 +977,11 @@ namespace Hl7.Cql.Runtime
             {
                 if (interval.low!.Precision == interval.high!.Precision)
                 {
-/*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                    per = new CqlQuantity(1, ucmunits);*/
                     Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
                     per = new CqlQuantity(1, cqlunits);
                 }
                 else if (interval.low.Precision < interval.high.Precision)
                 {
-/*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                    per = new CqlQuantity(1, ucmunits);*/
                     Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
                     per = new CqlQuantity(1, cqlunits);
 
@@ -1018,8 +989,6 @@ namespace Hl7.Cql.Runtime
                 }
                 else
                 {
-/*                    Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
-                    per = new CqlQuantity(1, ucmunits);*/
                     Units.DatePrecisionToCqlUnits.TryGetValue(interval.high.Precision.ToString(), out var cqlunits);
                     per = new CqlQuantity(1, cqlunits);
 
@@ -1032,7 +1001,6 @@ namespace Hl7.Cql.Runtime
                 {
                     // per has a coarser precision than the interval so nothing is added
                     case "hour":
-                    case "hours":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Hour
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Hour)
                             return expanded;
@@ -1044,7 +1012,6 @@ namespace Hl7.Cql.Runtime
 
                         break;
                     case "minute":
-                    case "minutes":
                         if (interval.low!.Precision < Iso8601.DateTimePrecision.Minute
                             && interval.high!.Precision < Iso8601.DateTimePrecision.Minute)
                             return expanded;
@@ -1056,7 +1023,6 @@ namespace Hl7.Cql.Runtime
 
                         break;
                     case "second":
-                    case "seconds":
                         if (interval.low!.Precision > Iso8601.DateTimePrecision.Second
                             && interval.high!.Precision > Iso8601.DateTimePrecision.Second)
                             return expanded;
@@ -1070,13 +1036,9 @@ namespace Hl7.Cql.Runtime
                     // parsed as a date unit when it's a time so return empty list
                     // ex: Interval[@T10, @T10] per month
                     case "year":
-                    case "years":
                     case "month":
-                    case "months":
                     case "day":
-                    case "days":
                     case "week":
-                    case "weeks":
                         return expanded;
                 }
             }
@@ -1153,10 +1115,8 @@ namespace Hl7.Cql.Runtime
                 per = new CqlQuantity(1, "1");
             else
             {
-/*                Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
-                if (ucumUnits != null)
-                    return expanded;*/
-                if (per.unit is not null && Units.cqlDateTimeUnits.Contains(per.unit))
+                // If the per quantity is a datetime, bypass the expansion of input interval of type decimal
+                if (per.unit is not null && Units.CqlDateTimeUnits.Contains(per.unit))
                     return expanded;
             }
 
@@ -1191,10 +1151,8 @@ namespace Hl7.Cql.Runtime
                 per = new CqlQuantity(1, "1");
             else
             {
-/*                Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
-                if (ucumUnits != null)
-                    return expanded;*/
-                if (per.unit is not null && Units.cqlDateTimeUnits.Contains(per.unit))
+                // If the per quantity is a datetime, bypass the expansion of input interval of type integer
+                if (per.unit is not null && Units.CqlDateTimeUnits.Contains(per.unit))
                     return expanded;
             }
 
@@ -1231,10 +1189,8 @@ namespace Hl7.Cql.Runtime
                 per = new CqlQuantity(1, "1");
             else
             {
-                /*                Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
-                                if (ucumUnits != null)
-                                    return expanded;*/
-                if (per.unit is not null && Units.cqlDateTimeUnits.Contains(per.unit))
+                // If the per quantity is a datetime, bypass the expansion of input interval of type long
+                if (per.unit is not null && Units.CqlDateTimeUnits.Contains(per.unit))
                     return expanded;
             }
 

--- a/Cql/Cql.Operators/CqlOperators.IntervalOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.IntervalOperators.cs
@@ -1001,13 +1001,15 @@ namespace Hl7.Cql.Runtime
                 {
 /*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
                     per = new CqlQuantity(1, ucmunits);*/
-                    per = new CqlQuantity(1, interval.low.Precision.ToString());
+                    Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
+                    per = new CqlQuantity(1, cqlunits);
                 }
                 else if (interval.low.Precision < interval.high.Precision)
                 {
 /*                    Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
                     per = new CqlQuantity(1, ucmunits);*/
-                    per = new CqlQuantity(1, interval.low.Precision.ToString());
+                    Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
+                    per = new CqlQuantity(1, cqlunits);
 
                     setHighPrecisionToPer = true;
                 }
@@ -1015,7 +1017,8 @@ namespace Hl7.Cql.Runtime
                 {
 /*                    Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
                     per = new CqlQuantity(1, ucmunits);*/
-                    per = new CqlQuantity(1, interval.high.Precision.ToString());
+                    Units.DatePrecisionToCqlUnits.TryGetValue(interval.high.Precision.ToString(), out var cqlunits);
+                    per = new CqlQuantity(1, cqlunits);
 
                     setLowPrecisionToPer = true;
                 }

--- a/Cql/Cql.Operators/CqlOperators.IntervalOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.IntervalOperators.cs
@@ -1116,7 +1116,7 @@ namespace Hl7.Cql.Runtime
             else
             {
                 // If the per quantity is a datetime, bypass the expansion of input interval of type decimal
-                if (per.unit is not null && Units.CqlDateTimeUnits.Contains(per.unit))
+                if (per.unit is not null && Units.DatePrecisionToCqlUnits.Values.Contains(per.unit))
                     return expanded;
             }
 
@@ -1152,7 +1152,7 @@ namespace Hl7.Cql.Runtime
             else
             {
                 // If the per quantity is a datetime, bypass the expansion of input interval of type integer
-                if (per.unit is not null && Units.CqlDateTimeUnits.Contains(per.unit))
+                if (per.unit is not null && Units.DatePrecisionToCqlUnits.Values.Contains(per.unit))
                     return expanded;
             }
 
@@ -1190,7 +1190,7 @@ namespace Hl7.Cql.Runtime
             else
             {
                 // If the per quantity is a datetime, bypass the expansion of input interval of type long
-                if (per.unit is not null && Units.CqlDateTimeUnits.Contains(per.unit))
+                if (per.unit is not null && Units.DatePrecisionToCqlUnits.Values.Contains(per.unit))
                     return expanded;
             }
 

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -217,15 +217,11 @@ namespace Hl7.Cql.Runtime
                     {
                         if (interval.low!.Precision == interval.high!.Precision)
                         {
-/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);*/
                             Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
                             per = new CqlQuantity(1, cqlunits);
                         }
                         else if (interval.low.Precision < interval.high.Precision)
                         {
-                            /*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                                                        per = new CqlQuantity(1, ucmunits);*/
                             Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
                             per = new CqlQuantity(1, cqlunits);
 
@@ -233,8 +229,6 @@ namespace Hl7.Cql.Runtime
                         }
                         else
                         {
-/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);*/
                             Units.DatePrecisionToCqlUnits.TryGetValue(interval.high.Precision.ToString(), out var cqlunits);
                             per = new CqlQuantity(1, cqlunits);
 
@@ -246,7 +240,6 @@ namespace Hl7.Cql.Runtime
                         switch (per.unit)
                         {
                             case "month":
-                            case "months":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Month
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Month)
                                     return expanded;
@@ -259,9 +252,7 @@ namespace Hl7.Cql.Runtime
 
                                 break;
                             case "day":
-                            case "days":
                             case "week":
-                            case "weeks":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Day
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Day)
                                     return expanded;
@@ -275,13 +266,9 @@ namespace Hl7.Cql.Runtime
                             // parsed as a time unit when it's a date so default to the coarsest
                             // ex: Interval[2023-01-01, 2023-12-31] per minute
                             case "hour":
-                            case "hours":
                             case "minute":
-                            case "minutes":
                             case "second":
-                            case "seconds":
                             case "millisecond":
-                            case "milliseconds":
                                 return expanded!;
                         }
                     }
@@ -325,7 +312,6 @@ namespace Hl7.Cql.Runtime
 
                     do
                     {
-                        //var precision = UCUMUnits.FromDateTimePrecision(listItem!.Precision);
                         Units.DatePrecisionToCqlUnits.TryGetValue(listItem!.Precision.ToString(), out var cqlunits);
 
                         // high is one less than next grouping using the smallest precision of the interval
@@ -372,15 +358,11 @@ namespace Hl7.Cql.Runtime
                     {
                         if (interval.low!.Precision == interval.high!.Precision)
                         {
-/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);*/
                             Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
                             per = new CqlQuantity(1, cqlunits);
                         }
                         else if (interval.low.Precision < interval.high.Precision)
                         {
-/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);*/
                             Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
                             per = new CqlQuantity(1, cqlunits);
 
@@ -388,8 +370,6 @@ namespace Hl7.Cql.Runtime
                         }
                         else
                         {
-/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);*/
                             Units.DatePrecisionToCqlUnits.TryGetValue(interval.high.Precision.ToString(), out var cqlunits);
                             per = new CqlQuantity(1, cqlunits);
 
@@ -401,7 +381,6 @@ namespace Hl7.Cql.Runtime
                         switch (per.unit)
                         {
                             case "month":
-                            case "months":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Month
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Month)
                                     return expanded;
@@ -413,9 +392,7 @@ namespace Hl7.Cql.Runtime
 
                                 break;
                             case "day":
-                            case "days":
                             case "week":
-                            case "weeks":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Day
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Day)
                                     return expanded;
@@ -428,7 +405,6 @@ namespace Hl7.Cql.Runtime
                                 break;
                             // per has a coarser precision than the interval so nothing is added
                             case "hour":
-                            case "hours":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Hour
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Hour)
                                     return expanded;
@@ -440,7 +416,6 @@ namespace Hl7.Cql.Runtime
 
                                 break;
                             case "minute":
-                            case "minutes":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Minute
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Minute)
                                     return expanded;
@@ -452,7 +427,6 @@ namespace Hl7.Cql.Runtime
 
                                 break;
                             case "second":
-                            case "seconds":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Second
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Second)
                                     return expanded;
@@ -529,7 +503,6 @@ namespace Hl7.Cql.Runtime
 
                     do
                     {
-                        //var precision = UCUMUnits.FromDateTimePrecision(listItem!.Precision);
                         Units.DatePrecisionToCqlUnits.TryGetValue(listItem!.Precision.ToString(), out var cqlunits);
 
                         // high is one less than next grouping using the smallest precision of the interval
@@ -575,15 +548,11 @@ namespace Hl7.Cql.Runtime
                     {
                         if (interval.low!.Precision == interval.high!.Precision)
                         {
-/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);*/
                             Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
                             per = new CqlQuantity(1, cqlunits);
                         }
                         else if (interval.low.Precision < interval.high.Precision)
                         {
-/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);*/
                             Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
                             per = new CqlQuantity(1, cqlunits);
 
@@ -591,8 +560,6 @@ namespace Hl7.Cql.Runtime
                         }
                         else
                         {
-/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);*/
                             Units.DatePrecisionToCqlUnits.TryGetValue(interval.high.Precision.ToString(), out var cqlunits);
                             per = new CqlQuantity(1, cqlunits);
 
@@ -605,7 +572,6 @@ namespace Hl7.Cql.Runtime
                         {
                             // per has a coarser precision than the interval so nothing is added
                             case "hour":
-                            case "hours":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Hour
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Hour)
                                     continue;
@@ -617,7 +583,6 @@ namespace Hl7.Cql.Runtime
 
                                 break;
                             case "minute":
-                            case "minutes":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Minute
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Minute)
                                     continue;
@@ -629,7 +594,6 @@ namespace Hl7.Cql.Runtime
 
                                 break;
                             case "second":
-                            case "seconds":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Second
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Second)
                                     continue;
@@ -644,13 +608,9 @@ namespace Hl7.Cql.Runtime
                             // parsed as a date unit when it's a time so return empty list
                             // ex: Interval[@T10, @T10] per month
                             case "year":
-                            case "years":
                             case "month":
-                            case "months":
                             case "day":
-                            case "days":
                             case "week":
-                            case "weeks":
                                 continue;
                         }
                     }
@@ -699,7 +659,6 @@ namespace Hl7.Cql.Runtime
 
                     do
                     {
-                        var precision = UCUMUnits.FromDateTimePrecision(listItem!.Precision);
                         Units.DatePrecisionToCqlUnits.TryGetValue(listItem!.Precision.ToString(), out var cqlunits);
 
                         // high is one less than next grouping using the smallest precision of the interval
@@ -744,19 +703,14 @@ namespace Hl7.Cql.Runtime
                         per = new CqlQuantity(1, "1");
                     else
                     {
-/*                        Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
-                        if (ucumUnits != null)
-                            continue;*/
-
-                        if (per.unit is not null && Units.cqlDateTimeUnits.Contains(per.unit))
+                        // If the per quantity is a datetime, bypass the expansion of input interval of type decimal
+                        if (per.unit is not null && Units.CqlDateTimeUnits.Contains(per.unit))
                             continue;
                     }
 
                     var listItem = interval.low!.Value;
                     do
                     {
-
-
                         var high = decimal.Add(listItem, per.value ?? 1);
                         var listInterval = new CqlInterval<decimal?>(listItem, Predecessor(high), true, true);
                         expanded.Add(listInterval);
@@ -795,10 +749,8 @@ namespace Hl7.Cql.Runtime
                         per = new CqlQuantity(1, "1");
                     else
                     {
-                        /*                        Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
-                                                if (ucumUnits != null)
-                                                    continue;*/
-                        if (per.unit is not null && Units.cqlDateTimeUnits.Contains(per.unit))
+                        // If the per quantity is a datetime, bypass the expansion of input interval of type integer
+                        if (per.unit is not null && Units.CqlDateTimeUnits.Contains(per.unit))
                             continue;
                     }
 
@@ -845,10 +797,8 @@ namespace Hl7.Cql.Runtime
                         per = new CqlQuantity(1, "1");
                     else
                     {
-                        /*                        Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
-                                                if (ucumUnits != null)
-                                                    continue;*/
-                        if (per.unit is not null && Units.cqlDateTimeUnits.Contains(per.unit))
+                        // If the per quantity is a datetime, bypass the expansion of input interval of type long
+                        if (per.unit is not null && Units.CqlDateTimeUnits.Contains(per.unit))
                             continue;
                     }
 

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -699,7 +699,7 @@ namespace Hl7.Cql.Runtime
 
                     do
                     {
-                        //var precision = UCUMUnits.FromDateTimePrecision(listItem!.Precision);
+                        var precision = UCUMUnits.FromDateTimePrecision(listItem!.Precision);
                         Units.DatePrecisionToCqlUnits.TryGetValue(listItem!.Precision.ToString(), out var cqlunits);
 
                         // high is one less than next grouping using the smallest precision of the interval

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -704,7 +704,7 @@ namespace Hl7.Cql.Runtime
                     else
                     {
                         // If the per quantity is a datetime, bypass the expansion of input interval of type decimal
-                        if (per.unit is not null && Units.CqlDateTimeUnits.Contains(per.unit))
+                        if (per.unit is not null && Units.DatePrecisionToCqlUnits.Values.Contains(per.unit))
                             continue;
                     }
 
@@ -750,7 +750,7 @@ namespace Hl7.Cql.Runtime
                     else
                     {
                         // If the per quantity is a datetime, bypass the expansion of input interval of type integer
-                        if (per.unit is not null && Units.CqlDateTimeUnits.Contains(per.unit))
+                        if (per.unit is not null && Units.DatePrecisionToCqlUnits.Values.Contains(per.unit))
                             continue;
                     }
 
@@ -798,7 +798,7 @@ namespace Hl7.Cql.Runtime
                     else
                     {
                         // If the per quantity is a datetime, bypass the expansion of input interval of type long
-                        if (per.unit is not null && Units.CqlDateTimeUnits.Contains(per.unit))
+                        if (per.unit is not null && Units.DatePrecisionToCqlUnits.Values.Contains(per.unit))
                             continue;
                     }
 

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -217,20 +217,26 @@ namespace Hl7.Cql.Runtime
                     {
                         if (interval.low!.Precision == interval.high!.Precision)
                         {
-                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);
+/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
+                            per = new CqlQuantity(1, ucmunits);*/
+                            Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
+                            per = new CqlQuantity(1, cqlunits);
                         }
                         else if (interval.low.Precision < interval.high.Precision)
                         {
-                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);
+                            /*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
+                                                        per = new CqlQuantity(1, ucmunits);*/
+                            Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
+                            per = new CqlQuantity(1, cqlunits);
 
                             setHighPrecisionToPer = true;
                         }
                         else
                         {
-                            Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);
+/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
+                            per = new CqlQuantity(1, ucmunits);*/
+                            Units.DatePrecisionToCqlUnits.TryGetValue(interval.high.Precision.ToString(), out var cqlunits);
+                            per = new CqlQuantity(1, cqlunits);
 
                             setLowPrecisionToPer = true;
                         }
@@ -239,7 +245,8 @@ namespace Hl7.Cql.Runtime
                     {
                         switch (per.unit)
                         {
-                            case "mo":
+                            case "month":
+                            case "months":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Month
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Month)
                                     return expanded;
@@ -251,8 +258,10 @@ namespace Hl7.Cql.Runtime
 
 
                                 break;
-                            case "d":
-                            case "wk":
+                            case "day":
+                            case "days":
+                            case "week":
+                            case "weeks":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Day
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Day)
                                     return expanded;
@@ -265,10 +274,14 @@ namespace Hl7.Cql.Runtime
                                 break;
                             // parsed as a time unit when it's a date so default to the coarsest
                             // ex: Interval[2023-01-01, 2023-12-31] per minute
-                            case "h":
-                            case "min":
-                            case "s":
-                            case "ms":
+                            case "hour":
+                            case "hours":
+                            case "minute":
+                            case "minutes":
+                            case "second":
+                            case "seconds":
+                            case "millisecond":
+                            case "milliseconds":
                                 return expanded!;
                         }
                     }
@@ -358,20 +371,23 @@ namespace Hl7.Cql.Runtime
                     {
                         if (interval.low!.Precision == interval.high!.Precision)
                         {
-                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);
+/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
+                            per = new CqlQuantity(1, ucmunits);*/
+                            per = new CqlQuantity(1, interval.low.Precision.ToString());
                         }
                         else if (interval.low.Precision < interval.high.Precision)
                         {
-                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);
+/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
+                            per = new CqlQuantity(1, ucmunits);*/
+                            per = new CqlQuantity(1, interval.low.Precision.ToString());
 
                             setHighPrecisionToPer = true;
                         }
                         else
                         {
-                            Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);
+/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
+                            per = new CqlQuantity(1, ucmunits);*/
+                            per = new CqlQuantity(1, interval.high.Precision.ToString());
 
                             setLowPrecisionToPer = true;
                         }
@@ -380,7 +396,8 @@ namespace Hl7.Cql.Runtime
                     {
                         switch (per.unit)
                         {
-                            case "mo":
+                            case "month":
+                            case "months":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Month
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Month)
                                     return expanded;
@@ -391,8 +408,10 @@ namespace Hl7.Cql.Runtime
                                     setHighPrecisionToPer = true;
 
                                 break;
-                            case "d":
-                            case "wk":
+                            case "day":
+                            case "days":
+                            case "week":
+                            case "weeks":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Day
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Day)
                                     return expanded;
@@ -404,7 +423,8 @@ namespace Hl7.Cql.Runtime
 
                                 break;
                             // per has a coarser precision than the interval so nothing is added
-                            case "h":
+                            case "hour":
+                            case "hours":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Hour
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Hour)
                                     return expanded;
@@ -415,7 +435,8 @@ namespace Hl7.Cql.Runtime
                                     setHighPrecisionToPer = true;
 
                                 break;
-                            case "min":
+                            case "minute":
+                            case "minutes":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Minute
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Minute)
                                     return expanded;
@@ -426,7 +447,8 @@ namespace Hl7.Cql.Runtime
                                     setHighPrecisionToPer = true;
 
                                 break;
-                            case "s":
+                            case "second":
+                            case "seconds":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Second
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Second)
                                     return expanded;
@@ -548,20 +570,23 @@ namespace Hl7.Cql.Runtime
                     {
                         if (interval.low!.Precision == interval.high!.Precision)
                         {
-                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);
+/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
+                            per = new CqlQuantity(1, ucmunits);*/
+                            per = new CqlQuantity(1, interval.low.Precision.ToString());
                         }
                         else if (interval.low.Precision < interval.high.Precision)
                         {
-                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);
+/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
+                            per = new CqlQuantity(1, ucmunits);*/
+                            per = new CqlQuantity(1, interval.low.Precision.ToString());
 
                             setHighPrecisionToPer = true;
                         }
                         else
                         {
-                            Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
-                            per = new CqlQuantity(1, ucmunits);
+/*                            Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
+                            per = new CqlQuantity(1, ucmunits);*/
+                            per = new CqlQuantity(1, interval.high.Precision.ToString());
 
                             setLowPrecisionToPer = true;
                         }
@@ -703,8 +728,11 @@ namespace Hl7.Cql.Runtime
                         per = new CqlQuantity(1, "1");
                     else
                     {
-                        Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
+/*                        Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
                         if (ucumUnits != null)
+                            continue;*/
+
+                        if (per.unit is not null && Units.cqlDateTimeUnits.Contains(per.unit))
                             continue;
                     }
 
@@ -751,8 +779,10 @@ namespace Hl7.Cql.Runtime
                         per = new CqlQuantity(1, "1");
                     else
                     {
-                        Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
-                        if (ucumUnits != null)
+                        /*                        Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
+                                                if (ucumUnits != null)
+                                                    continue;*/
+                        if (per.unit is not null && Units.cqlDateTimeUnits.Contains(per.unit))
                             continue;
                     }
 
@@ -799,8 +829,10 @@ namespace Hl7.Cql.Runtime
                         per = new CqlQuantity(1, "1");
                     else
                     {
-                        Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
-                        if (ucumUnits != null)
+                        /*                        Units.UCUMUnitsToCql.TryGetValue(per.unit ?? "", out var ucumUnits);
+                                                if (ucumUnits != null)
+                                                    continue;*/
+                        if (per.unit is not null && Units.cqlDateTimeUnits.Contains(per.unit))
                             continue;
                     }
 

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -325,11 +325,12 @@ namespace Hl7.Cql.Runtime
 
                     do
                     {
-                        var precision = UCUMUnits.FromDateTimePrecision(listItem!.Precision);
+                        //var precision = UCUMUnits.FromDateTimePrecision(listItem!.Precision);
+                        Units.DatePrecisionToCqlUnits.TryGetValue(listItem!.Precision.ToString(), out var cqlunits);
 
                         // high is one less than next grouping using the smallest precision of the interval
                         // expand { Interval[@2022-01-01, @2024-03-01] } per 2 years returns { [2022-01-01, 2023-12-31], [2024-01-01, 2025-12-31] }
-                        var onePrior = new CqlQuantity(1, precision);
+                        var onePrior = new CqlQuantity(1, cqlunits);
                         var next = listItem.Add(per);
 
                         var high = next!.Subtract(onePrior);
@@ -373,13 +374,15 @@ namespace Hl7.Cql.Runtime
                         {
 /*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
                             per = new CqlQuantity(1, ucmunits);*/
-                            per = new CqlQuantity(1, interval.low.Precision.ToString());
+                            Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
+                            per = new CqlQuantity(1, cqlunits);
                         }
                         else if (interval.low.Precision < interval.high.Precision)
                         {
 /*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
                             per = new CqlQuantity(1, ucmunits);*/
-                            per = new CqlQuantity(1, interval.low.Precision.ToString());
+                            Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
+                            per = new CqlQuantity(1, cqlunits);
 
                             setHighPrecisionToPer = true;
                         }
@@ -387,7 +390,8 @@ namespace Hl7.Cql.Runtime
                         {
 /*                            Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
                             per = new CqlQuantity(1, ucmunits);*/
-                            per = new CqlQuantity(1, interval.high.Precision.ToString());
+                            Units.DatePrecisionToCqlUnits.TryGetValue(interval.high.Precision.ToString(), out var cqlunits);
+                            per = new CqlQuantity(1, cqlunits);
 
                             setLowPrecisionToPer = true;
                         }
@@ -525,10 +529,11 @@ namespace Hl7.Cql.Runtime
 
                     do
                     {
-                        var precision = UCUMUnits.FromDateTimePrecision(listItem!.Precision);
+                        //var precision = UCUMUnits.FromDateTimePrecision(listItem!.Precision);
+                        Units.DatePrecisionToCqlUnits.TryGetValue(listItem!.Precision.ToString(), out var cqlunits);
 
                         // high is one less than next grouping using the smallest precision of the interval
-                        var onePrior = new CqlQuantity(1, precision);
+                        var onePrior = new CqlQuantity(1, cqlunits);
                         var next = listItem.Add(per);
 
                         var high = next!.Subtract(onePrior);
@@ -572,13 +577,15 @@ namespace Hl7.Cql.Runtime
                         {
 /*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
                             per = new CqlQuantity(1, ucmunits);*/
-                            per = new CqlQuantity(1, interval.low.Precision.ToString());
+                            Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
+                            per = new CqlQuantity(1, cqlunits);
                         }
                         else if (interval.low.Precision < interval.high.Precision)
                         {
 /*                            Units.CqlUnitsToUCUM.TryGetValue(interval.low.Precision.ToString(), out var ucmunits);
                             per = new CqlQuantity(1, ucmunits);*/
-                            per = new CqlQuantity(1, interval.low.Precision.ToString());
+                            Units.DatePrecisionToCqlUnits.TryGetValue(interval.low.Precision.ToString(), out var cqlunits);
+                            per = new CqlQuantity(1, cqlunits);
 
                             setHighPrecisionToPer = true;
                         }
@@ -586,7 +593,8 @@ namespace Hl7.Cql.Runtime
                         {
 /*                            Units.CqlUnitsToUCUM.TryGetValue(interval.high.Precision.ToString(), out var ucmunits);
                             per = new CqlQuantity(1, ucmunits);*/
-                            per = new CqlQuantity(1, interval.high.Precision.ToString());
+                            Units.DatePrecisionToCqlUnits.TryGetValue(interval.high.Precision.ToString(), out var cqlunits);
+                            per = new CqlQuantity(1, cqlunits);
 
                             setLowPrecisionToPer = true;
                         }
@@ -596,7 +604,8 @@ namespace Hl7.Cql.Runtime
                         switch (per.unit)
                         {
                             // per has a coarser precision than the interval so nothing is added
-                            case "h":
+                            case "hour":
+                            case "hours":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Hour
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Hour)
                                     continue;
@@ -607,7 +616,8 @@ namespace Hl7.Cql.Runtime
                                     setHighPrecisionToPer = true;
 
                                 break;
-                            case "min":
+                            case "minute":
+                            case "minutes":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Minute
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Minute)
                                     continue;
@@ -618,7 +628,8 @@ namespace Hl7.Cql.Runtime
                                     setHighPrecisionToPer = true;
 
                                 break;
-                            case "s":
+                            case "second":
+                            case "seconds":
                                 if (interval.low!.Precision < Iso8601.DateTimePrecision.Second
                                     && interval.high!.Precision < Iso8601.DateTimePrecision.Second)
                                     continue;
@@ -632,10 +643,14 @@ namespace Hl7.Cql.Runtime
                                 break;
                             // parsed as a date unit when it's a time so return empty list
                             // ex: Interval[@T10, @T10] per month
-                            case "a":
-                            case "mo":
-                            case "d":
-                            case "wk":
+                            case "year":
+                            case "years":
+                            case "month":
+                            case "months":
+                            case "day":
+                            case "days":
+                            case "week":
+                            case "weeks":
                                 continue;
                         }
                     }
@@ -684,10 +699,11 @@ namespace Hl7.Cql.Runtime
 
                     do
                     {
-                        var precision = UCUMUnits.FromDateTimePrecision(listItem!.Precision);
+                        //var precision = UCUMUnits.FromDateTimePrecision(listItem!.Precision);
+                        Units.DatePrecisionToCqlUnits.TryGetValue(listItem!.Precision.ToString(), out var cqlunits);
 
                         // high is one less than next grouping using the smallest precision of the interval
-                        var onePrior = new CqlQuantity(1, precision);
+                        var onePrior = new CqlQuantity(1, cqlunits);
                         var next = listItem.Add(per);
 
                         var high = next!.Subtract(onePrior);

--- a/Cql/Cql.Operators/CqlOperators.TypeOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.TypeOperators.cs
@@ -208,8 +208,7 @@ namespace Hl7.Cql.Runtime
         {
             if (argument == null || argument.value == null || unit == null)
                 return null;
-/*            if (Units.CqlUnitsToUCUM.TryGetValue(unit, out var converted))
-                unit = converted;*/
+
             var newQuantity = UnitConverter.ChangeUnits(argument, unit);
             return newQuantity;
         }

--- a/Cql/Cql.Operators/CqlOperators.TypeOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.TypeOperators.cs
@@ -208,8 +208,8 @@ namespace Hl7.Cql.Runtime
         {
             if (argument == null || argument.value == null || unit == null)
                 return null;
-            if (Units.CqlUnitsToUCUM.TryGetValue(unit, out var converted))
-                unit = converted;
+/*            if (Units.CqlUnitsToUCUM.TryGetValue(unit, out var converted))
+                unit = converted;*/
             var newQuantity = UnitConverter.ChangeUnits(argument, unit);
             return newQuantity;
         }

--- a/Cql/Cql.Primitives/CqlDate.cs
+++ b/Cql/Cql.Primitives/CqlDate.cs
@@ -273,8 +273,6 @@ namespace Hl7.Cql.Primitives
                 dtp = (DateTimePrecision)Math.Max((byte)Value.Precision, (byte)other.Value.Precision);
             else
             {
-/*                if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                    precision = converted;*/
                 // weeks isn't part of the precision enumeration
                 if (precision == "week" || precision == "weeks")
                 {
@@ -299,7 +297,7 @@ namespace Hl7.Cql.Primitives
                 dtp = precision.ToDateTimePrecision() ?? DateTimePrecision.Unknown;
             }
             if (dtp == DateTimePrecision.Unknown)
-                throw new ArgumentException($"Invalid UCUM precision {precision}", nameof(precision));
+                throw new ArgumentException($"Invalid precision {precision}", nameof(precision));
             switch (dtp)
             {
                 case DateTimePrecision.Year:
@@ -335,7 +333,7 @@ namespace Hl7.Cql.Primitives
                 case DateTimePrecision.Millisecond:
                 case DateTimePrecision.Unknown:
                 default:
-                    throw new ArgumentException($"Invalid UCUM precision {precision}", nameof(precision));
+                    throw new ArgumentException($"Invalid precision {precision}", nameof(precision));
             }
         }
 

--- a/Cql/Cql.Primitives/CqlDate.cs
+++ b/Cql/Cql.Primitives/CqlDate.cs
@@ -222,11 +222,14 @@ namespace Hl7.Cql.Primitives
                 precision = converted;*/
             switch (precision)
             {
-                case UCUMUnits.Year:
+                case "year":
+                case "years":
                     return Value.Year;
-                case UCUMUnits.Month:
+                case "month":
+                case "months":
                     return Value.Month;
-                case UCUMUnits.Day:
+                case "day":
+                case "days":
                     return Value.Day;
                 default:
                     return null;

--- a/Cql/Cql.Primitives/CqlDate.cs
+++ b/Cql/Cql.Primitives/CqlDate.cs
@@ -102,39 +102,38 @@ namespace Hl7.Cql.Primitives
             if (dto.Date.Equals(DateTimeOffset.MaxValue.Date))
                 return null;
 
-            switch (quantity.unit[0])
+            switch (quantity.unit)
             {
-                case 'a':
+                case "year":
+                case "years":
                     dto = dto.AddYears((int)value);
                     break;
-                case 'm':
-                    if (quantity.unit.Length > 1)
-                    {
-                        switch (quantity.unit[1])
-                        {
-                            case 'o':
-                                dto = dto.AddMonths((int)value);
-                                break;
-                            case 'i':
-                                dto = dto.AddMinutes(Math.Truncate((double)value));
-                                break;
-                            case 's':
-                                dto = dto.AddMilliseconds(Math.Truncate((double)value));
-                                break;
-                            default: throw new ArgumentException($"Unknown date unit {quantity.unit} supplied");
-                        }
-                    }
+                case "month":
+                case "months":
+                    dto = dto.AddMonths((int)value);
                     break;
-                case 'd':
+                case "minute":
+                case "minutes":
+                    dto = dto.AddMinutes(Math.Truncate((double)value));
+                    break;
+                case "millisecond":
+                case "milliseconds":
+                    dto = dto.AddMilliseconds(Math.Truncate((double)value));
+                    break;
+                case "day":
+                case "days":
                     dto = dto.AddDays((int)value!);
                     break;
-                case 'w':
+                case "week":
+                case "weeks":
                     dto = dto.AddDays((int)(value! * CqlDateTimeMath.DaysPerWeek));
                     break;
-                case 'h':
+                case "hour":
+                case "hours":
                     dto = dto.AddHours(Math.Truncate((double)value));
                     break;
-                case 's':
+                case "second":
+                case "seconds":
                     dto = dto.AddSeconds(Math.Truncate((double)value));
                     break;
                 default: throw new ArgumentException($"Unknown date unit {quantity.unit} supplied");
@@ -220,8 +219,8 @@ namespace Hl7.Cql.Primitives
         /// <returns>The individual component at the specified precision, or <see langword="null"/> if this date is not expressed in those units.</returns>
         public int? Component(string precision)
         {
-            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                precision = converted;
+/*            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
+                precision = converted;*/
             switch (precision)
             {
                 case UCUMUnits.Year:

--- a/Cql/Cql.Primitives/CqlDate.cs
+++ b/Cql/Cql.Primitives/CqlDate.cs
@@ -163,39 +163,38 @@ namespace Hl7.Cql.Primitives
 
             try
             {
-                switch (quantity.unit[0])
+                switch (quantity.unit)
                 {
-                    case 'a':
+                    case "year":
+                    case "years":
                         dto = dto.AddYears((int)value);
                         break;
-                    case 'm':
-                        if (quantity.unit.Length > 1)
-                        {
-                            switch (quantity.unit[1])
-                            {
-                                case 'o':
-                                    dto = dto.AddMonths((int)value);
-                                    break;
-                                case 'i':
-                                    dto = dto.AddMinutes(Math.Truncate((double)value));
-                                    break;
-                                case 's':
-                                    dto = dto.AddMilliseconds(Math.Truncate((double)value));
-                                    break;
-                                default: throw new ArgumentException($"Unknown date unit {quantity.unit} supplied");
-                            }
-                        }
+                    case "month":
+                    case "months":
+                        dto = dto.AddMonths((int)value);
                         break;
-                    case 'd':
+                    case "minute":
+                    case "minutes":
+                        dto = dto.AddMinutes(Math.Truncate((double)value));
+                        break;
+                    case "millisecond":
+                    case "milliseconds":
+                        dto = dto.AddMilliseconds(Math.Truncate((double)value));
+                        break;
+                    case "day":
+                    case "days":
                         dto = dto.AddDays((int)value!);
                         break;
-                    case 'w':
+                    case "week":
+                    case "weeks":
                         dto = dto.AddDays((int)(value! * CqlDateTimeMath.DaysPerWeek));
                         break;
-                    case 'h':
+                    case "hour":
+                    case "hours":
                         dto = dto.AddHours(Math.Truncate((double)value));
                         break;
-                    case 's':
+                    case "second":
+                    case "seconds":
                         dto = dto.AddSeconds(Math.Truncate((double)value));
                         break;
                     default: throw new ArgumentException($"Unknown date unit {quantity.unit} supplied");

--- a/Cql/Cql.Primitives/CqlDate.cs
+++ b/Cql/Cql.Primitives/CqlDate.cs
@@ -270,10 +270,10 @@ namespace Hl7.Cql.Primitives
                 dtp = (DateTimePrecision)Math.Max((byte)Value.Precision, (byte)other.Value.Precision);
             else
             {
-                if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                    precision = converted;
+/*                if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
+                    precision = converted;*/
                 // weeks isn't part of the precision enumeration
-                if (precision[0] == 'w')
+                if (precision == "week" || precision == "weeks")
                 {
                     var yearComparison = Compare(Value.Year, other.Value.Year);
                     if (yearComparison == 0)

--- a/Cql/Cql.Primitives/CqlDate.cs
+++ b/Cql/Cql.Primitives/CqlDate.cs
@@ -214,22 +214,17 @@ namespace Hl7.Cql.Primitives
         /// <summary>
         /// Gets the component of this date.
         /// </summary>
-        /// <param name="precision">The CQL or UCUM unit precision.</param>
+        /// <param name="precision">The CQL unit precision.</param>
         /// <returns>The individual component at the specified precision, or <see langword="null"/> if this date is not expressed in those units.</returns>
         public int? Component(string precision)
         {
-/*            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                precision = converted;*/
             switch (precision)
             {
                 case "year":
-                case "years":
                     return Value.Year;
                 case "month":
-                case "months":
                     return Value.Month;
                 case "day":
-                case "days":
                     return Value.Day;
                 default:
                     return null;

--- a/Cql/Cql.Primitives/CqlDateTime.cs
+++ b/Cql/Cql.Primitives/CqlDateTime.cs
@@ -155,39 +155,38 @@ namespace Hl7.Cql.Primitives
             if (dto.Equals(DateTimeOffset.MaxValue))
                 return null;
 
-            switch (quantity.unit[0])
+            switch (quantity.unit)
             {
-                case 'a':
+                case "year":
+                case "years":
                     dto = dto.AddYears((int)value);
                     break;
-                case 'm':
-                    if (quantity.unit.Length > 1)
-                    {
-                        switch (quantity.unit[1])
-                        {
-                            case 'o':
-                                dto = dto.AddMonths((int)value);
-                                break;
-                            case 'i':
-                                dto = dto.AddMinutes(Math.Truncate((double)value));
-                                break;
-                            case 's':
-                                dto = dto.AddMilliseconds(Math.Truncate((double)value));
-                                break;
-                            default: throw new ArgumentException($"Unknown date unit {quantity.unit} supplied");
-                        }
-                    }
+                case "month":
+                case "months":
+                    dto = dto.AddMonths((int)value);
                     break;
-                case 'd':
+                case "minute":
+                case "minutes":
+                    dto = dto.AddMinutes(Math.Truncate((double)value));
+                    break;
+                case "millisecond":
+                case "milliseconds":
+                    dto = dto.AddMilliseconds(Math.Truncate((double)value));
+                    break;
+                case "day":
+                case "days":
                     dto = dto.AddDays((int)value!);
                     break;
-                case 'w':
+                case "week":
+                case "weeks":
                     dto = dto.AddDays((int)(value! * CqlDateTimeMath.DaysPerWeek));
                     break;
-                case 'h':
+                case "hour":
+                case "hours":
                     dto = dto.AddHours(Math.Truncate((double)value));
                     break;
-                case 's':
+                case "second":
+                case "seconds":
                     dto = dto.AddSeconds(Math.Truncate((double)value));
                     break;
                 default: throw new ArgumentException($"Unknown date unit {quantity.unit} supplied");
@@ -215,39 +214,38 @@ namespace Hl7.Cql.Primitives
             if (dto.Equals(DateTimeOffset.MinValue))
                 return null;
 
-            switch (quantity.unit[0])
+            switch (quantity.unit)
             {
-                case 'a':
+                case "year":
+                case "years":
                     dto = dto.AddYears((int)value);
                     break;
-                case 'm':
-                    if (quantity.unit.Length > 1)
-                    {
-                        switch (quantity.unit[1])
-                        {
-                            case 'o':
-                                dto = dto.AddMonths((int)value);
-                                break;
-                            case 'i':
-                                dto = dto.AddMinutes(Math.Truncate((double)value));
-                                break;
-                            case 's':
-                                dto = dto.AddMilliseconds(Math.Truncate((double)value));
-                                break;
-                            default: throw new ArgumentException($"Unknown date unit {quantity.unit} supplied");
-                        }
-                    }
+                case "month":
+                case "months":
+                    dto = dto.AddMonths((int)value);
                     break;
-                case 'd':
+                case "minute":
+                case "minutes":
+                    dto = dto.AddMinutes(Math.Truncate((double)value));
+                    break;
+                case "millisecond":
+                case "milliseconds":
+                    dto = dto.AddMilliseconds(Math.Truncate((double)value));
+                    break;
+                case "day":
+                case "days":
                     dto = dto.AddDays((int)value!);
                     break;
-                case 'w':
+                case "week":
+                case "weeks":
                     dto = dto.AddDays((int)(value! * CqlDateTimeMath.DaysPerWeek));
                     break;
-                case 'h':
+                case "hour":
+                case "hours":
                     dto = dto.AddHours(Math.Truncate((double)value));
                     break;
-                case 's':
+                case "second":
+                case "seconds":
                     dto = dto.AddSeconds(Math.Truncate((double)value));
                     break;
                 default: throw new ArgumentException($"Unknown date unit {quantity.unit} supplied");

--- a/Cql/Cql.Primitives/CqlDateTime.cs
+++ b/Cql/Cql.Primitives/CqlDateTime.cs
@@ -263,23 +263,31 @@ namespace Hl7.Cql.Primitives
         /// <returns>The individual component at the specified precision, or <see langword="null"/> if this date is not expressed in those units.</returns>
         public int? Component(string precision)
         {
-/*            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                precision = converted;*/
+            /*            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
+                            precision = converted;*/
+
             switch (precision)
             {
-                case UCUMUnits.Year:
+                case "year":
+                case "years":
                     return Value.Year;
-                case UCUMUnits.Month:
+                case "month":
+                case "months":
                     return Value.Month;
-                case UCUMUnits.Day:
+                case "day":
+                case "days":
                     return Value.Day;
-                case UCUMUnits.Hour:
+                case "hour":
+                case "hours":
                     return Value.Hour;
-                case UCUMUnits.Minute:
+                case "minute":
+                case "minutes":
                     return Value.Minute;
-                case UCUMUnits.Second:
+                case "second":
+                case "seconds":
                     return Value.Second;
-                case UCUMUnits.Millisecond:
+                case "millisecond":
+                case "milliseconds":
                     return Value.Millisecond;
                 default:
                     return null;

--- a/Cql/Cql.Primitives/CqlDateTime.cs
+++ b/Cql/Cql.Primitives/CqlDateTime.cs
@@ -263,8 +263,8 @@ namespace Hl7.Cql.Primitives
         /// <returns>The individual component at the specified precision, or <see langword="null"/> if this date is not expressed in those units.</returns>
         public int? Component(string precision)
         {
-            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                precision = converted;
+/*            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
+                precision = converted;*/
             switch (precision)
             {
                 case UCUMUnits.Year:
@@ -343,10 +343,10 @@ namespace Hl7.Cql.Primitives
                 dtp = (DateTimePrecision)Math.Max((byte)Value.Precision, (byte)other.Value.Precision);
             else
             {
-                if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                    precision = converted;
+/*                if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
+                    precision = converted;*/
                 // weeks isn't part of the precision enumeration
-                if (precision[0] == 'w')
+                if (precision == "week" || precision == "weeks")
                 {
                     var yearComparison = Compare(Value.Year, other.Value.Year);
                     if (yearComparison == 0)

--- a/Cql/Cql.Primitives/CqlDateTime.cs
+++ b/Cql/Cql.Primitives/CqlDateTime.cs
@@ -259,35 +259,25 @@ namespace Hl7.Cql.Primitives
         /// <summary>
         /// Gets the component of this date time.
         /// </summary>
-        /// <param name="precision">The CQL or UCUM unit precision.</param>
+        /// <param name="precision">The CQL unit precision.</param>
         /// <returns>The individual component at the specified precision, or <see langword="null"/> if this date is not expressed in those units.</returns>
         public int? Component(string precision)
         {
-            /*            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                            precision = converted;*/
-
             switch (precision)
             {
                 case "year":
-                case "years":
                     return Value.Year;
                 case "month":
-                case "months":
                     return Value.Month;
                 case "day":
-                case "days":
                     return Value.Day;
                 case "hour":
-                case "hours":
                     return Value.Hour;
                 case "minute":
-                case "minutes":
                     return Value.Minute;
                 case "second":
-                case "seconds":
                     return Value.Second;
                 case "millisecond":
-                case "milliseconds":
                     return Value.Millisecond;
                 default:
                     return null;
@@ -351,8 +341,6 @@ namespace Hl7.Cql.Primitives
                 dtp = (DateTimePrecision)Math.Max((byte)Value.Precision, (byte)other.Value.Precision);
             else
             {
-/*                if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                    precision = converted;*/
                 // weeks isn't part of the precision enumeration
                 if (precision == "week" || precision == "weeks")
                 {
@@ -377,12 +365,12 @@ namespace Hl7.Cql.Primitives
                 dtp = precision.ToDateTimePrecision() ?? DateTimePrecision.Unknown;
             }
             if (dtp == DateTimePrecision.Unknown)
-                throw new ArgumentException($"Invalid UCUM precision {precision}", nameof(precision));
+                throw new ArgumentException($"Invalid precision {precision}", nameof(precision));
             switch (dtp)
             {
                 default:
                 case DateTimePrecision.Unknown:
-                    throw new ArgumentException($"Invalid UCUM precision {precision}", nameof(precision));
+                    throw new ArgumentException($"Invalid precision {precision}", nameof(precision));
                 case DateTimePrecision.Year:
                     return Compare(Value.Year, other.Value.Year);
                 case DateTimePrecision.Month:

--- a/Cql/Cql.Primitives/CqlDateTimeMath.cs
+++ b/Cql/Cql.Primitives/CqlDateTimeMath.cs
@@ -218,13 +218,20 @@ namespace Hl7.Cql.Primitives
 
         internal static readonly IDictionary<DateTimePrecision, CqlQuantity> UnitDateTimeQuantity = new Dictionary<DateTimePrecision, CqlQuantity>
         {
-            { DateTimePrecision.Day, new CqlQuantity(1m, UCUMUnits.Day) },
+/*            { DateTimePrecision.Day, new CqlQuantity(1m, UCUMUnits.Day) },
             { DateTimePrecision.Hour, new CqlQuantity(1m, UCUMUnits.Hour) },
             { DateTimePrecision.Millisecond, new CqlQuantity(1m, UCUMUnits.Millisecond) },
             { DateTimePrecision.Minute, new CqlQuantity(1m, UCUMUnits.Minute) },
             { DateTimePrecision.Month, new CqlQuantity(1m, UCUMUnits.Month) },
             { DateTimePrecision.Second, new CqlQuantity(1m, UCUMUnits.Second) },
-            { DateTimePrecision.Year, new CqlQuantity(1m, UCUMUnits.Year) },
+            { DateTimePrecision.Year, new CqlQuantity(1m, UCUMUnits.Year) },*/
+            { DateTimePrecision.Day, new CqlQuantity(1m, "day") },
+            { DateTimePrecision.Hour, new CqlQuantity(1m, "hour") },
+            { DateTimePrecision.Millisecond, new CqlQuantity(1m, "millisecond") },
+            { DateTimePrecision.Minute, new CqlQuantity(1m, "minute") },
+            { DateTimePrecision.Month, new CqlQuantity(1m, "month") },
+            { DateTimePrecision.Second, new CqlQuantity(1m, "second") },
+            { DateTimePrecision.Year, new CqlQuantity(1m, "year") },
 
         };
     }

--- a/Cql/Cql.Primitives/CqlDateTimeMath.cs
+++ b/Cql/Cql.Primitives/CqlDateTimeMath.cs
@@ -33,20 +33,23 @@ namespace Hl7.Cql.Primitives
         {
             if (low == null || high == null || precision == null)
                 return null;
-            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                precision = converted;
+/*            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
+                precision = converted;*/
 
             var firstDto = low.Value;
             var secondDto = high.Value;
             switch (precision)
             {
-                case "a":
+                case "year":
+                case "years":
                     var yearDiff = (secondDto.Year - firstDto.Year);
                     return yearDiff;
-                case "mo":
+                case "month":
+                case "months":
                     var monthDiff = (12 * (secondDto.Year - firstDto.Year) + secondDto.Month - firstDto.Month);
                     return monthDiff;
-                case "wk":
+                case "week":
+                case "weeks":
                     {
                         var span = secondDto.Subtract(firstDto);
                         var weeks = span.TotalDays / 7d;
@@ -57,7 +60,8 @@ namespace Hl7.Cql.Primitives
                             return asInt + 1;
                         else return asInt;
                     }
-                case "d":
+                case "day":
+                case "days":
                     {
                         var span = secondDto.Subtract(firstDto);
                         var asInt = (int)span.TotalDays;
@@ -69,7 +73,8 @@ namespace Hl7.Cql.Primitives
                         }
                         else return asInt;
                     }
-                case "h":
+                case "hour":
+                case "hours":
                     {
                         var span = secondDto.Subtract(firstDto);
                         var asInt = (int)span.TotalHours;
@@ -81,7 +86,8 @@ namespace Hl7.Cql.Primitives
                         }
                         else return asInt;
                     }
-                case "min":
+                case "minute":
+                case "minutes":
                     {
                         var span = secondDto.Subtract(firstDto);
                         var asInt = (int)span.TotalMinutes;
@@ -93,7 +99,8 @@ namespace Hl7.Cql.Primitives
                         }
                         else return asInt;
                     }
-                case "s":
+                case "second":
+                case "seconds":
                     {
                         var span = secondDto.Subtract(firstDto);
                         var asInt = (int)span.TotalSeconds;
@@ -105,7 +112,8 @@ namespace Hl7.Cql.Primitives
                         }
                         else return asInt;
                     }
-                case "ms":
+                case "millisecond":
+                case "milliseconds":
                     {
                         var span = secondDto.Subtract(firstDto);
                         var asInt = (int)span.TotalMilliseconds;
@@ -125,15 +133,16 @@ namespace Hl7.Cql.Primitives
         {
             if (low == null || high == null || precision == null)
                 return null;
-            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                precision = converted;
+/*            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
+                precision = converted;*/
 
             var calendar = new GregorianCalendar();
             var firstDto = low.Value;
             var secondDto = high.Value;
             switch (precision)
             {
-                case "a":
+                case "year":
+                case "years":
                     var yearDiff = secondDto.Year - firstDto.Year;
                     var firstDayInYear = firstDto.DayOfYear;
                     var secondDayInYear = secondDto.DayOfYear;
@@ -199,20 +208,34 @@ namespace Hl7.Cql.Primitives
                     else if (yearDiff < 0 && firstDayInYear < secondDayInYear)
                         yearDiff += 1;
                     return yearDiff;
-                case "mo":
+                case "month":
+                case "months":
                     var monthDiff = (12 * (secondDto.Year - firstDto.Year) + secondDto.Month - firstDto.Month);
                     if (monthDiff > 0 && secondDto.Day < firstDto.Day)
                         monthDiff -= 1;
                     else if (monthDiff < 0 && firstDto.Day < secondDto.Day)
                         monthDiff += 1;
                     return monthDiff;
-                case "wk": return (int)(secondDto.Subtract(firstDto).TotalDays / DaysPerWeekDouble);
-                case "d": return (int)secondDto.Subtract(firstDto).TotalDays;
-                case "h": return (int)secondDto.Subtract(firstDto).TotalHours;
-                case "min": return (int)secondDto.Subtract(firstDto).TotalMinutes;
-                case "s": return (int)secondDto.Subtract(firstDto).TotalSeconds;
-                case "ms": return (int)secondDto.Subtract(firstDto).TotalMilliseconds;
-                default: throw new ArgumentException($"Unit {precision} is not supported");
+                case "week":
+                case "weeks": 
+                    return (int)(secondDto.Subtract(firstDto).TotalDays / DaysPerWeekDouble);
+                case "day":
+                case "days": 
+                    return (int)secondDto.Subtract(firstDto).TotalDays;
+                case "hour":
+                case "hours": 
+                    return (int)secondDto.Subtract(firstDto).TotalHours;
+                case "minute":
+                case "minutes": 
+                    return (int)secondDto.Subtract(firstDto).TotalMinutes;
+                case "second":
+                case "seconds": 
+                    return (int)secondDto.Subtract(firstDto).TotalSeconds;
+                case "millisecond":
+                case "milliseconds": 
+                    return (int)secondDto.Subtract(firstDto).TotalMilliseconds;
+                default: 
+                    throw new ArgumentException($"Unit {precision} is not supported");
             };
         }
 

--- a/Cql/Cql.Primitives/CqlDateTimeMath.cs
+++ b/Cql/Cql.Primitives/CqlDateTimeMath.cs
@@ -33,23 +33,18 @@ namespace Hl7.Cql.Primitives
         {
             if (low == null || high == null || precision == null)
                 return null;
-/*            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                precision = converted;*/
 
             var firstDto = low.Value;
             var secondDto = high.Value;
             switch (precision)
             {
                 case "year":
-                case "years":
                     var yearDiff = (secondDto.Year - firstDto.Year);
                     return yearDiff;
                 case "month":
-                case "months":
                     var monthDiff = (12 * (secondDto.Year - firstDto.Year) + secondDto.Month - firstDto.Month);
                     return monthDiff;
                 case "week":
-                case "weeks":
                     {
                         var span = secondDto.Subtract(firstDto);
                         var weeks = span.TotalDays / 7d;
@@ -61,7 +56,6 @@ namespace Hl7.Cql.Primitives
                         else return asInt;
                     }
                 case "day":
-                case "days":
                     {
                         var span = secondDto.Subtract(firstDto);
                         var asInt = (int)span.TotalDays;
@@ -74,7 +68,6 @@ namespace Hl7.Cql.Primitives
                         else return asInt;
                     }
                 case "hour":
-                case "hours":
                     {
                         var span = secondDto.Subtract(firstDto);
                         var asInt = (int)span.TotalHours;
@@ -87,7 +80,6 @@ namespace Hl7.Cql.Primitives
                         else return asInt;
                     }
                 case "minute":
-                case "minutes":
                     {
                         var span = secondDto.Subtract(firstDto);
                         var asInt = (int)span.TotalMinutes;
@@ -100,7 +92,6 @@ namespace Hl7.Cql.Primitives
                         else return asInt;
                     }
                 case "second":
-                case "seconds":
                     {
                         var span = secondDto.Subtract(firstDto);
                         var asInt = (int)span.TotalSeconds;
@@ -113,7 +104,6 @@ namespace Hl7.Cql.Primitives
                         else return asInt;
                     }
                 case "millisecond":
-                case "milliseconds":
                     {
                         var span = secondDto.Subtract(firstDto);
                         var asInt = (int)span.TotalMilliseconds;
@@ -133,8 +123,6 @@ namespace Hl7.Cql.Primitives
         {
             if (low == null || high == null || precision == null)
                 return null;
-/*            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                precision = converted;*/
 
             var calendar = new GregorianCalendar();
             var firstDto = low.Value;
@@ -142,7 +130,6 @@ namespace Hl7.Cql.Primitives
             switch (precision)
             {
                 case "year":
-                case "years":
                     var yearDiff = secondDto.Year - firstDto.Year;
                     var firstDayInYear = firstDto.DayOfYear;
                     var secondDayInYear = secondDto.DayOfYear;
@@ -209,30 +196,23 @@ namespace Hl7.Cql.Primitives
                         yearDiff += 1;
                     return yearDiff;
                 case "month":
-                case "months":
                     var monthDiff = (12 * (secondDto.Year - firstDto.Year) + secondDto.Month - firstDto.Month);
                     if (monthDiff > 0 && secondDto.Day < firstDto.Day)
                         monthDiff -= 1;
                     else if (monthDiff < 0 && firstDto.Day < secondDto.Day)
                         monthDiff += 1;
                     return monthDiff;
-                case "week":
-                case "weeks": 
+                case "week": 
                     return (int)(secondDto.Subtract(firstDto).TotalDays / DaysPerWeekDouble);
-                case "day":
-                case "days": 
+                case "day": 
                     return (int)secondDto.Subtract(firstDto).TotalDays;
-                case "hour":
-                case "hours": 
+                case "hour": 
                     return (int)secondDto.Subtract(firstDto).TotalHours;
-                case "minute":
-                case "minutes": 
+                case "minute": 
                     return (int)secondDto.Subtract(firstDto).TotalMinutes;
-                case "second":
-                case "seconds": 
+                case "second": 
                     return (int)secondDto.Subtract(firstDto).TotalSeconds;
-                case "millisecond":
-                case "milliseconds": 
+                case "millisecond": 
                     return (int)secondDto.Subtract(firstDto).TotalMilliseconds;
                 default: 
                     throw new ArgumentException($"Unit {precision} is not supported");
@@ -241,13 +221,6 @@ namespace Hl7.Cql.Primitives
 
         internal static readonly IDictionary<DateTimePrecision, CqlQuantity> UnitDateTimeQuantity = new Dictionary<DateTimePrecision, CqlQuantity>
         {
-/*            { DateTimePrecision.Day, new CqlQuantity(1m, UCUMUnits.Day) },
-            { DateTimePrecision.Hour, new CqlQuantity(1m, UCUMUnits.Hour) },
-            { DateTimePrecision.Millisecond, new CqlQuantity(1m, UCUMUnits.Millisecond) },
-            { DateTimePrecision.Minute, new CqlQuantity(1m, UCUMUnits.Minute) },
-            { DateTimePrecision.Month, new CqlQuantity(1m, UCUMUnits.Month) },
-            { DateTimePrecision.Second, new CqlQuantity(1m, UCUMUnits.Second) },
-            { DateTimePrecision.Year, new CqlQuantity(1m, UCUMUnits.Year) },*/
             { DateTimePrecision.Day, new CqlQuantity(1m, "day") },
             { DateTimePrecision.Hour, new CqlQuantity(1m, "hour") },
             { DateTimePrecision.Millisecond, new CqlQuantity(1m, "millisecond") },

--- a/Cql/Cql.Primitives/CqlQuantity.cs
+++ b/Cql/Cql.Primitives/CqlQuantity.cs
@@ -7,6 +7,7 @@
  */
 
 using Hl7.Cql.Abstractions;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.ConstrainedExecution;
 
@@ -30,9 +31,14 @@ namespace Hl7.Cql.Primitives
         /// <param name="value">The value of this quantity.</param>
         /// <param name="unit">The units of this quantity.</param>
         public CqlQuantity(decimal? value, string? unit)
-        {
-            this.value = value;
-            this.unit = unit;
+        {   
+            if (unit != null && !UCUMUnits.DateTimeUnits.Contains(unit))
+            {
+                this.value = value;
+                this.unit = unit;
+            }
+            else
+                this.value = value;
         }
 
         /// <summary>

--- a/Cql/Cql.Primitives/CqlQuantity.cs
+++ b/Cql/Cql.Primitives/CqlQuantity.cs
@@ -28,11 +28,10 @@ namespace Hl7.Cql.Primitives
         /// Creates an instance.
         /// </summary>
         /// <param name="value">The value of this quantity.</param>
-        /// <param name="unit">The UCUM units of this quantity.</param>
+        /// <param name="unit">The units of this quantity.</param>
         public CqlQuantity(decimal? value, string? unit)
         {
             this.value = value;
-            //this.unit = unit != null && Units.CqlUnitsToUCUM.TryGetValue(unit, out var ucumUnits) ? ucumUnits : unit;
             this.unit = unit;
         }
 
@@ -42,7 +41,7 @@ namespace Hl7.Cql.Primitives
         public decimal? value { get; init; }
 
         /// <summary>
-        /// The UCUM units of this quantity.
+        /// The units of this quantity.
         /// </summary>
         public string? unit { get; init;  }
 
@@ -54,10 +53,6 @@ namespace Hl7.Cql.Primitives
             if (value == null || unit == null)
                 return null;
             var unitString = unit;
-/*            if (Units.UCUMUnitsToCql.TryGetValue(unit, out var cqlUnit))
-            {
-                unitString = cqlUnit;
-            }*/
 
             return string.Create(CultureInfo.InvariantCulture, $"{value}{unitString}");
         }

--- a/Cql/Cql.Primitives/CqlQuantity.cs
+++ b/Cql/Cql.Primitives/CqlQuantity.cs
@@ -8,6 +8,7 @@
 
 using Hl7.Cql.Abstractions;
 using System.Globalization;
+using System.Runtime.ConstrainedExecution;
 
 namespace Hl7.Cql.Primitives
 {
@@ -31,7 +32,8 @@ namespace Hl7.Cql.Primitives
         public CqlQuantity(decimal? value, string? unit)
         {
             this.value = value;
-            this.unit = unit != null && Units.CqlUnitsToUCUM.TryGetValue(unit, out var ucumUnits) ? ucumUnits : unit;
+            //this.unit = unit != null && Units.CqlUnitsToUCUM.TryGetValue(unit, out var ucumUnits) ? ucumUnits : unit;
+            this.unit = unit;
         }
 
         /// <summary>
@@ -52,10 +54,10 @@ namespace Hl7.Cql.Primitives
             if (value == null || unit == null)
                 return null;
             var unitString = unit;
-            if (Units.UCUMUnitsToCql.TryGetValue(unit, out var cqlUnit))
+/*            if (Units.UCUMUnitsToCql.TryGetValue(unit, out var cqlUnit))
             {
                 unitString = cqlUnit;
-            }
+            }*/
 
             return string.Create(CultureInfo.InvariantCulture, $"{value}{unitString}");
         }

--- a/Cql/Cql.Primitives/CqlTime.cs
+++ b/Cql/Cql.Primitives/CqlTime.cs
@@ -106,33 +106,30 @@ namespace Hl7.Cql.Primitives
             if (span.Equals(TimeSpan.MaxValue))
                 return null;
 
-            switch (quantity.unit[0])
+            switch (quantity.unit)
             {
-                case 'm':
-                    if (quantity.unit.Length > 1)
-                    {
-                        switch (quantity.unit[1])
-                        {
-                            case 'i':
-                                span = span.Add(TimeSpan.FromMinutes(Math.Truncate((double)value)));
-                                break;
-                            case 's':
-                                span = span.Add(TimeSpan.FromMilliseconds(Math.Truncate((double)value)));
-                                break;
-                            default: throw new ArgumentException($"Unknown date unit {quantity.unit} supplied");
-                        }
-                    }
+                case "minute":
+                case "minutes":
+                    span = span.Add(TimeSpan.FromMinutes(Math.Truncate((double)value)));
                     break;
-                case 'd':
+                case "millisecond":
+                case "milliseconds":
+                    span = span.Add(TimeSpan.FromMilliseconds(Math.Truncate((double)value)));
+                    break;
+                case "day":
+                case "days":
                     span = span.Add(TimeSpan.FromDays(Math.Truncate((double)value)));
                     break;
-                case 'w':
+                case "week":
+                case "weeks":
                     span = span.Add(TimeSpan.FromDays(Math.Truncate((double)value) * CqlDateTimeMath.DaysPerWeekDouble));
                     break;
-                case 'h':
+                case "hour":
+                case "hours":
                     span = span.Add(TimeSpan.FromHours(Math.Truncate((double)value)));
                     break;
-                case 's':
+                case "second":
+                case "seconds":
                     span = span.Add(TimeSpan.FromSeconds(Math.Truncate((double)value)));
                     break;
                 default: throw new ArgumentException($"Unknown date unit {quantity.unit} supplied");
@@ -160,33 +157,30 @@ namespace Hl7.Cql.Primitives
             if (span.Equals(TimeSpan.MinValue))
                 return null;
 
-            switch (quantity.unit[0])
+            switch (quantity.unit)
             {
-                case 'm':
-                    if (quantity.unit.Length > 1)
-                    {
-                        switch (quantity.unit[1])
-                        {
-                            case 'i':
-                                span = span.Subtract(TimeSpan.FromMinutes(Math.Truncate((double)value)));
-                                break;
-                            case 's':
-                                span = span.Subtract(TimeSpan.FromMilliseconds(Math.Truncate((double)value)));
-                                break;
-                            default: throw new ArgumentException($"Unknown date unit {quantity.unit} supplied");
-                        }
-                    }
+                case "minute":
+                case "minutes":
+                    span = span.Subtract(TimeSpan.FromMinutes(Math.Truncate((double)value)));
                     break;
-                case 'd':
+                case "millisecond":
+                case "milliseconds":
+                    span = span.Subtract(TimeSpan.FromMilliseconds(Math.Truncate((double)value)));
+                    break;
+                case "day":
+                case "days":
                     span = span.Subtract(TimeSpan.FromDays(Math.Truncate((double)value)));
                     break;
-                case 'w':
+                case "week":
+                case "weeks":
                     span = span.Subtract(TimeSpan.FromDays(Math.Truncate((double)value) * CqlDateTimeMath.DaysPerWeekDouble));
                     break;
-                case 'h':
+                case "hour":
+                case "hours":
                     span = span.Subtract(TimeSpan.FromHours(Math.Truncate((double)value)));
                     break;
-                case 's':
+                case "second":
+                case "seconds":
                     span = span.Subtract(TimeSpan.FromSeconds(Math.Truncate((double)value)));
                     break;
                 default: throw new ArgumentException($"Unknown date unit {quantity.unit} supplied");

--- a/Cql/Cql.Primitives/CqlTime.cs
+++ b/Cql/Cql.Primitives/CqlTime.cs
@@ -194,25 +194,19 @@ namespace Hl7.Cql.Primitives
         /// <summary>
         /// Gets the component of this time.
         /// </summary>
-        /// <param name="precision">The CQL or UCUM unit precision.</param>
+        /// <param name="precision">The CQL unit precision.</param>
         /// <returns>The individual component at the specified precision, or <see langword="null"/> if this date is not expressed in those units.</returns>
         public int? Component(string precision)
         {
-/*            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                precision = converted;*/
             switch (precision)
             {
                 case "hour":
-                case "hours":
                     return Value.Hour;
                 case "minute":
-                case "minutes":
                     return Value.Minute;
                 case "second":
-                case "seconds":
                     return Value.Second;
                 case "millisecond":
-                case "milliseconds":
                     return Value.Millisecond;
                 default:
                     return null;
@@ -274,12 +268,10 @@ namespace Hl7.Cql.Primitives
                 dtp = (DateTimePrecision)Math.Max((byte)Value.Precision, (byte)other.Value.Precision);
             else
             {
-/*                if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                    precision = converted;*/
                 dtp = precision.ToDateTimePrecision() ?? DateTimePrecision.Unknown;
             }
             if (dtp == DateTimePrecision.Unknown)
-                throw new ArgumentException($"Invalid UCUM precision {precision}", nameof(precision));
+                throw new ArgumentException($"Invalid precision {precision}", nameof(precision));
             switch (dtp)
             {
 
@@ -368,7 +360,7 @@ namespace Hl7.Cql.Primitives
                 case DateTimePrecision.Month:
                 case DateTimePrecision.Day:
                 default:
-                    throw new ArgumentException($"Invalid UCUM precision {precision}", nameof(precision));
+                    throw new ArgumentException($"Invalid precision {precision}", nameof(precision));
             }
         }
 

--- a/Cql/Cql.Primitives/CqlTime.cs
+++ b/Cql/Cql.Primitives/CqlTime.cs
@@ -202,13 +202,17 @@ namespace Hl7.Cql.Primitives
                 precision = converted;*/
             switch (precision)
             {
-                case UCUMUnits.Hour:
+                case "hour":
+                case "hours":
                     return Value.Hour;
-                case UCUMUnits.Minute:
+                case "minute":
+                case "minutes":
                     return Value.Minute;
-                case UCUMUnits.Second:
+                case "second":
+                case "seconds":
                     return Value.Second;
-                case UCUMUnits.Millisecond:
+                case "millisecond":
+                case "milliseconds":
                     return Value.Millisecond;
                 default:
                     return null;

--- a/Cql/Cql.Primitives/CqlTime.cs
+++ b/Cql/Cql.Primitives/CqlTime.cs
@@ -198,8 +198,8 @@ namespace Hl7.Cql.Primitives
         /// <returns>The individual component at the specified precision, or <see langword="null"/> if this date is not expressed in those units.</returns>
         public int? Component(string precision)
         {
-            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                precision = converted;
+/*            if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
+                precision = converted;*/
             switch (precision)
             {
                 case UCUMUnits.Hour:
@@ -270,8 +270,8 @@ namespace Hl7.Cql.Primitives
                 dtp = (DateTimePrecision)Math.Max((byte)Value.Precision, (byte)other.Value.Precision);
             else
             {
-                if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
-                    precision = converted;
+/*                if (Units.CqlUnitsToUCUM.TryGetValue(precision, out var converted))
+                    precision = converted;*/
                 dtp = precision.ToDateTimePrecision() ?? DateTimePrecision.Unknown;
             }
             if (dtp == DateTimePrecision.Unknown)

--- a/Cql/Iso8601/DateTimePrecision.cs
+++ b/Cql/Iso8601/DateTimePrecision.cs
@@ -11,11 +11,11 @@ namespace Hl7.Cql.Iso8601
 {
     public static class DateTimePrecisionExtensions
     {
-        public static DateTimePrecision? ToDateTimePrecision(this string? ucumUnit)
+        public static DateTimePrecision? ToDateTimePrecision(this string? unit)
         {
-            if (ucumUnit == null)
+            if (unit == null)
                 return null;
-            else switch (ucumUnit)
+            else switch (unit)
                 {
                     case "year":
                     case "years":

--- a/Cql/Iso8601/DateTimePrecision.cs
+++ b/Cql/Iso8601/DateTimePrecision.cs
@@ -15,27 +15,28 @@ namespace Hl7.Cql.Iso8601
         {
             if (ucumUnit == null)
                 return null;
-            else switch (ucumUnit[0])
+            else switch (ucumUnit)
                 {
-                    case 'a': // year
+                    case "year":
+                    case "years":
                         return DateTimePrecision.Year;
-                    case 'm': // month
-                        switch (ucumUnit[1])
-                        {
-                            case 'o': // mo = month
-                                return DateTimePrecision.Month;
-                            case 'i': // min = minute
-                                return DateTimePrecision.Minute;
-                            case 's':
-                                return DateTimePrecision.Millisecond;
-                            default: break;
-                        }
-                        break;
-                    case 'd':
+                    case "month":
+                    case "months":
+                        return DateTimePrecision.Month;
+                    case "minute":
+                    case "minutes":
+                        return DateTimePrecision.Minute;
+                    case "millisecond":
+                    case "milliseconds":
+                        return DateTimePrecision.Millisecond;
+                    case "day":
+                    case "days":
                         return DateTimePrecision.Day;
-                    case 'h':
+                    case "hour":
+                    case "hours":
                         return DateTimePrecision.Hour;
-                    case 's':
+                    case "second":
+                    case "seconds":
                         return DateTimePrecision.Second;
                     default:
                         break;


### PR DESCRIPTION
**Problem Statement**
The engine currently normalizes temporal units in CQL (e.g., 'year', 'years', 'month', 'months') to UCUM units (e.g., 'a', 'mo'). This normalization leads to incorrect behavior in date and time arithmetic, because UCUM units represent fixed durations, whereas CQL units represent calendar-based durations.

As per the CQL specification ([DateTime Arithmetic](https://cql.hl7.org/02-authorsguide.html#datetime-arithmetic)):

CQL temporal units are calendar-aware:
'year' means “1 calendar year” (e.g., @2024-02-29 - 1 year results in @2023-02-28)
'month' means “1 calendar month” (e.g., @2025-04-30 - 1 month results in @2025-03-30)

UCUM units like 'a' and 'mo' are fixed-duration quantities:
'a' = exactly 365.25 days
'mo' = exactly 30.4375 days

This distinction is critical. For example:
@2025-04-03 - 1 year => @2024-04-03
@2025-04-03 - 1 'a' =>  @2024-04-02T06:00:00 (due to subtracting 365.25 days)

Likewise:
2 years - 1 year
Expected result (per CQL): 1 year

Current behavior: 1 'a' (UCUM year), which affects downstream logic — e.g., a case expression looking for 'year' won't match.

**Scope of Fix**

- Identified and updated all areas in the engine where unit normalization or comparison is used in date and time arithmetic.
- Introduced case handling and preservation for native CQL temporal units:
- Added explicit handling for 'year', 'years', 'month', 'months', etc., during arithmetic and comparison.
- Avoided UCUM normalization in contexts where calendar semantics are required:
- This includes calculations involving CqlDateTime, CqlQuantity, and related primitives.
- Updated equality, subtraction, and comparison logic to respect the semantic meaning of calendar units in CQL.
- Preserved/Refactored Unit Conversion specifically for hedis use-case below _"convert gestationalQuantityWithCalendarUnit to weeks"