### PR TITLE
Adding In Valueset fix

### DIFF
--- a/Cql/Cql.Compiler/ExpressionBuilder.ClinicalOperators.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.ClinicalOperators.cs
@@ -40,8 +40,13 @@ namespace Hl7.Cql.Compiler
         protected Expression InValueSet(elm.InValueSet e, ExpressionBuilderContext ctx)
         {
             var code = TranslateExpression(e.code!, ctx);
-            var valueSet = InvokeDefinitionThroughRuntimeContext(e.valueset!.name!, e.valueset.libraryName, typeof(CqlValueSet), ctx);
-            var codeType = code.Type;
+            Expression valueSet;
+
+            if (e.valuesetExpression != null)
+                valueSet = TranslateExpression(e.valuesetExpression!, ctx);
+            else
+                valueSet = InvokeDefinitionThroughRuntimeContext(e.valueset!.name!, e.valueset.libraryName, typeof(CqlValueSet), ctx); var codeType = code.Type;
+
             if (codeType == TypeResolver.CodeType)
             {
                 return OperatorBinding.Bind(CqlOperator.CodeInValueSet, ctx.RuntimeContextParameter, code, valueSet);


### PR DESCRIPTION
```
define fluent function "Has"(c System.Code, valueSet System.ValueSet):
    if c is null or valueSet is null then null
    else 
        c in valueSet 
```
c in valueSet doesn't compile as the SDK resolve the valueSet expression. The fix will handle when the valueSet is supplied as expression