### PR TITLE
Handle take to slice transformation

### DIFF
--- a/Cql/CoreTests/ExpressionBuilderTests.cs
+++ b/Cql/CoreTests/ExpressionBuilderTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
+using System.Linq;
 
 namespace CoreTests
 {
@@ -93,6 +94,20 @@ namespace CoreTests
             var property = eb.GetProperty(typeof(MeasureReport.PopulationComponent), "id");
             Assert.AreEqual(typeof(Element), property.DeclaringType);
             Assert.AreEqual(nameof(Element.ElementId), property.Name);
+        }
+
+        [TestMethod]
+        public void Take_Induced_Slice_Test()
+        {
+            var binding = new CqlOperatorsBinding(TypeResolver, TypeConverter);
+            var typeManager = new TypeManager(TypeResolver);
+            var elm = new FileInfo(@"Input\ELM\Test\SliceTest-1.0.0.json");
+            var elmPackage = Hl7.Cql.Elm.Library.LoadFromJson(elm);
+            var logger = CreateLogger();
+            var eb = new ExpressionBuilder(binding, typeManager, elmPackage, logger);
+
+            var expressions = eb.Build();
+            Assert.IsNotNull(expressions);
         }
 
     }

--- a/Cql/CoreTests/Input/ELM/Test/SliceTest-1.0.0.cql
+++ b/Cql/CoreTests/Input/ELM/Test/SliceTest-1.0.0.cql
@@ -1,0 +1,24 @@
+library SliceTest version '1.0.0'
+
+using FHIR version '4.0.1'
+
+define "Input list":
+    {1, 2, 3, 4, 5, 6, 7, 8, 9, 10} as List<Integer>
+
+define "n":
+    5
+
+//@operation: take-induced-slice
+define fluent function "Take first n items"(list List<Integer>):
+    Take(list, "n")
+
+//@operation: take-induced-slice
+define "Take first 5 items":
+    Take("Input list", "n")
+
+
+define fluent function "Take first n plus 1 items"(list List<Integer>):
+    Take(list, "n")
+
+define "Take first n plus 1 items":
+    Take("Input list", "n")

--- a/Cql/CoreTests/Input/ELM/Test/SliceTest-1.0.0.cql
+++ b/Cql/CoreTests/Input/ELM/Test/SliceTest-1.0.0.cql
@@ -13,7 +13,7 @@ define fluent function "Take first n items"(list List<Integer>):
     Take(list, "n")
 
 //@operation: take-induced-slice
-define "Take first 5 items":
+define "Take first n items":
     Take("Input list", "n")
 
 

--- a/Cql/CoreTests/Input/ELM/Test/SliceTest-1.0.0.json
+++ b/Cql/CoreTests/Input/ELM/Test/SliceTest-1.0.0.json
@@ -1,0 +1,439 @@
+{
+  "library" : {
+    "type" : "Library",
+    "identifier" : {
+      "type" : "VersionedIdentifier",
+      "id" : "SliceTest",
+      "version" : "1.0.0"
+    },
+    "schemaIdentifier" : {
+      "type" : "VersionedIdentifier",
+      "id" : "urn:hl7-org:elm",
+      "version" : "r1"
+    },
+    "usings" : {
+      "type" : "Library$Usings",
+      "def" : [ {
+        "type" : "UsingDef",
+        "localIdentifier" : "System",
+        "uri" : "urn:hl7-org:elm-types:r1"
+      }, {
+        "type" : "UsingDef",
+        "locator" : "3:1-3:26",
+        "localIdentifier" : "FHIR",
+        "uri" : "http://hl7.org/fhir",
+        "version" : "4.0.1"
+      } ]
+    },
+    "statements" : {
+      "type" : "Library$Statements",
+      "def" : [ {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "As",
+          "asTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "locator" : "6:45-6:51",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            },
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer"
+              }
+            },
+            "locator" : "6:40-6:52"
+          },
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }
+          },
+          "operand" : {
+            "type" : "List",
+            "element" : [ {
+              "type" : "Literal",
+              "locator" : "6:6",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1"
+            }, {
+              "type" : "Literal",
+              "locator" : "6:9",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2"
+            }, {
+              "type" : "Literal",
+              "locator" : "6:12",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "3"
+            }, {
+              "type" : "Literal",
+              "locator" : "6:15",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "4"
+            }, {
+              "type" : "Literal",
+              "locator" : "6:18",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "5"
+            }, {
+              "type" : "Literal",
+              "locator" : "6:21",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "6"
+            }, {
+              "type" : "Literal",
+              "locator" : "6:24",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "7"
+            }, {
+              "type" : "Literal",
+              "locator" : "6:27",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "8"
+            }, {
+              "type" : "Literal",
+              "locator" : "6:30",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "9"
+            }, {
+              "type" : "Literal",
+              "locator" : "6:33-6:34",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "10"
+            } ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer"
+              }
+            },
+            "locator" : "6:5-6:35"
+          },
+          "locator" : "6:5-6:52",
+          "strict" : false
+        },
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer"
+          }
+        },
+        "locator" : "5:1-6:52",
+        "name" : "Input list",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Literal",
+          "locator" : "9:5",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+          "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+          "value" : "5"
+        },
+        "locator" : "8:1-9:5",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+        "name" : "n",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "FunctionDef",
+        "operand" : [ {
+          "type" : "OperandDef",
+          "operandTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "locator" : "12:55-12:61",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            },
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer"
+              }
+            },
+            "locator" : "12:50-12:62"
+          },
+          "name" : "list"
+        } ],
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ {
+            "name" : "operation",
+            "value" : "take-induced-slice"
+          } ]
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer"
+          }
+        },
+        "expression" : {
+          "type" : "Slice",
+          "source" : {
+            "type" : "OperandRef",
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer"
+              }
+            },
+            "locator" : "13:10-13:13",
+            "name" : "list"
+          },
+          "startIndex" : {
+            "type" : "Literal",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "0"
+          },
+          "endIndex" : {
+            "type" : "Coalesce",
+            "operand" : [ {
+              "type" : "ExpressionRef",
+              "locator" : "13:16-13:18",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "name" : "n"
+            }, {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            } ]
+          },
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }
+          },
+          "locator" : "13:5-13:19"
+        },
+        "locator" : "12:1-13:19",
+        "name" : "Take first n items",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "fluent" : true
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Slice",
+          "source" : {
+            "type" : "ExpressionRef",
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer"
+              }
+            },
+            "locator" : "17:10-17:21",
+            "name" : "Input list"
+          },
+          "startIndex" : {
+            "type" : "Literal",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "0"
+          },
+          "endIndex" : {
+            "type" : "Coalesce",
+            "operand" : [ {
+              "type" : "ExpressionRef",
+              "locator" : "17:24-17:26",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "name" : "n"
+            }, {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            } ]
+          },
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }
+          },
+          "locator" : "17:5-17:27"
+        },
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ {
+            "name" : "operation",
+            "value" : "take-induced-slice"
+          } ]
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer"
+          }
+        },
+        "locator" : "16:1-17:27",
+        "name" : "Take first 5 items",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "FunctionDef",
+        "operand" : [ {
+          "type" : "OperandDef",
+          "operandTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "locator" : "20:62-20:68",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            },
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer"
+              }
+            },
+            "locator" : "20:57-20:69"
+          },
+          "name" : "list"
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer"
+          }
+        },
+        "expression" : {
+          "type" : "Slice",
+          "source" : {
+            "type" : "OperandRef",
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer"
+              }
+            },
+            "locator" : "21:10-21:13",
+            "name" : "list"
+          },
+          "startIndex" : {
+            "type" : "Literal",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "0"
+          },
+          "endIndex" : {
+            "type" : "Coalesce",
+            "operand" : [ {
+              "type" : "ExpressionRef",
+              "locator" : "21:16-21:18",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "name" : "n"
+            }, {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            } ]
+          },
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }
+          },
+          "locator" : "21:5-21:19"
+        },
+        "locator" : "20:1-21:19",
+        "name" : "Take first n plus 1 items",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "fluent" : true
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Slice",
+          "source" : {
+            "type" : "ExpressionRef",
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer"
+              }
+            },
+            "locator" : "24:10-24:21",
+            "name" : "Input list"
+          },
+          "startIndex" : {
+            "type" : "Literal",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "0"
+          },
+          "endIndex" : {
+            "type" : "Coalesce",
+            "operand" : [ {
+              "type" : "ExpressionRef",
+              "locator" : "24:24-24:26",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "name" : "n"
+            }, {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            } ]
+          },
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }
+          },
+          "locator" : "24:5-24:27"
+        },
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer"
+          }
+        },
+        "locator" : "23:1-24:27",
+        "name" : "Take first n plus 1 items",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      } ]
+    },
+    "annotation" : [ {
+      "type" : "CqlToElmInfo",
+      "translatorOptions" : "EnableLocators,EnableResultTypes,DisableListTraversal,DisableListDemotion,DisableListPromotion"
+    } ]
+  }
+}

--- a/Cql/CoreTests/Input/ELM/Test/SliceTest-1.0.0.json
+++ b/Cql/CoreTests/Input/ELM/Test/SliceTest-1.0.0.json
@@ -296,7 +296,7 @@
           }
         },
         "locator" : "16:1-17:27",
-        "name" : "Take first 5 items",
+        "name" : "Take first n items",
         "context" : "Patient",
         "accessLevel" : "Public"
       }, {

--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -3577,5 +3577,57 @@ namespace CoreTests
             Assert.IsNotNull(meets);
             Assert.IsFalse(meets ?? false);
         }
+
+        [TestMethod]
+        public void Slice_test()
+        {
+            var rtx = GetNewContext();
+
+            //simple slicing
+            var inputList1 = new List<int> { 10, 11, 12, 13, 14, 15 };
+            var outputList1 = new List<int> { 12, 13, 14 };
+
+            var sliced1 = rtx.Operators.Slice(inputList1, 2, 4).ToArray();
+            var result1 = rtx.Operators.Comparer.Compare(outputList1!, sliced1!, null);
+            if (result1 != 0)
+                throw new AssertFailedException($"Expected {outputList1}; actual {sliced1}");
+
+            //mimic Skip(list,number)
+            var outputList2 = new List<int> { 13, 14, 15 };
+
+            var sliced2 = rtx.Operators.Slice(inputList1, 3, null).ToArray(); //skip first 3 indexes, so this sets startIndex to 3 meaning pull from 4th item in list till end
+            var result2 = rtx.Operators.Comparer.Compare(outputList2!, sliced2!, null);
+            if (result2 != 0)
+                throw new AssertFailedException($"Expected {outputList2}; actual {sliced2}");
+
+            //mimic Tail(list)
+            var outputList3 = new List<int> { 11, 12, 13, 14, 15 };
+
+            var sliced3 = rtx.Operators.Slice(inputList1, 1, null).ToArray(); //skip first index, so this sets startIndex to 1 meaning pull from 2nd item in list till end
+            var result3 = rtx.Operators.Comparer.Compare(outputList3!, sliced3!, null);
+            if (result3 != 0)
+                throw new AssertFailedException($"Expected {outputList3}; actual {sliced3}");
+
+            //mimic Take(list, number), where list is of type List<T>
+            var outputList4 = new List<int> { 10, 11, 12 };
+
+            //incorrectly take first 4 items, instead of first 3 items by setting startIndex to 0 and endIndex to 3, meaning it pulls first 4 items
+            var sliced4 = rtx.Operators.Slice(inputList1, 0, 3).ToArray();
+            var result4 = rtx.Operators.Comparer.Compare(outputList4!, sliced4!, null);
+            if (result4 != 0) //expected to not match, thats the bug with take->slice operation
+                Assert.IsNull(null, $"Expected {outputList4}; actual {sliced4}");
+
+            //mimic Take(list, number), where list is NOT of type List<T>
+            int[] inputList2 = { 10, 11, 12, 13, 14, 15 };
+            var outputList5 = new List<int> { 10, 11, 12 };
+
+            //incorrectly take first 4 items, instead of first 3 items by setting startIndex to 0 and endIndex to 3,
+            //but given the input list is not of type List<T>, Slice method skips endIndex, meaning it pulls first 3 items properly
+            var sliced5 = rtx.Operators.Slice(inputList2, 0, 3).ToArray();
+            var result5 = rtx.Operators.Comparer.Compare(outputList5!, sliced5!, null);
+            if (result5 != 0)
+                throw new AssertFailedException($"Expected {outputList3}; actual {sliced3}");
+        }
+
     }
 }

--- a/Cql/Cql.Compiler/ExpressionBuilder.ClinicalOperators.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.ClinicalOperators.cs
@@ -40,8 +40,13 @@ namespace Hl7.Cql.Compiler
         protected Expression InValueSet(elm.InValueSet e, ExpressionBuilderContext ctx)
         {
             var code = TranslateExpression(e.code!, ctx);
-            var valueSet = InvokeDefinitionThroughRuntimeContext(e.valueset!.name!, e.valueset.libraryName, typeof(CqlValueSet), ctx);
-            var codeType = code.Type;
+            Expression valueSet;
+
+            if (e.valuesetExpression != null)
+                valueSet = TranslateExpression(e.valuesetExpression!, ctx);
+            else
+                valueSet = InvokeDefinitionThroughRuntimeContext(e.valueset!.name!, e.valueset.libraryName, typeof(CqlValueSet), ctx); var codeType = code.Type;
+
             if (codeType == TypeResolver.CodeType)
             {
                 return OperatorBinding.Bind(CqlOperator.CodeInValueSet, ctx.RuntimeContextParameter, code, valueSet);

--- a/Cql/Cql.Compiler/ExpressionBuilder.ListOperators.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.ListOperators.cs
@@ -9,6 +9,7 @@
 
 using Hl7.Cql.Abstractions;
 using System;
+using System.Linq;
 using System.Linq.Expressions;
 using elm = Hl7.Cql.Elm;
 
@@ -64,12 +65,7 @@ namespace Hl7.Cql.Compiler
                 ? Expression.Constant(null, typeof(int?))
                 : TranslateExpression(slice.endIndex!, ctx);
 
-            Expression end = endExpr;
-
-            if (ctx.Parent != null && ctx.Parent is Hl7.Cql.Elm.FunctionDef parentElement && parentElement.name != null && parentElement.name.ToString() == "Take last item")
-            {
-                end = WrapWithAdditionalSubtract(endExpr, ctx);
-            }
+            Expression end = WrapWithSubtractExpression(endExpr, ctx);
 
             if (IsOrImplementsIEnumerableOfT(source.Type))
             {
@@ -78,23 +74,41 @@ namespace Hl7.Cql.Compiler
             throw new NotImplementedException();
         }
 
-        private Expression WrapWithAdditionalSubtract(Expression expression, ExpressionBuilderContext ctx)
+        private Expression WrapWithSubtractExpression(Expression expression, ExpressionBuilderContext ctx)
         {
-            //create new expression to Subtract given expression by 1 so as to yield the correct end index for slicing
-            var literal = new elm.Literal
+            if (ctx.Parent != null && ctx.Parent is Hl7.Cql.Elm.FunctionDef parentElement && parentElement.name != null)
             {
-                value = "1",
-                valueType = new System.Xml.XmlQualifiedName("{urn:hl7-org:elm-types:r1}Integer")
-            };
+                // Check for annotation-tag with name == "operation" and value == "take-induced-slice"
+                var annotations = parentElement.annotation ?? Array.Empty<Hl7.Cql.Elm.Annotation>();
+                bool hasTakeInducedSlice = annotations
+                    .OfType<Hl7.Cql.Elm.Annotation>()
+                    .SelectMany(a => a.t ?? Array.Empty<Hl7.Cql.Elm.Tag>())
+                    .Any(tag => tag.name == "operation" && tag.value == "take-induced-slice");
 
-            var literalOneExp = TranslateExpression(literal, ctx);
+                if (hasTakeInducedSlice)
+                {
+                    //create new expression to Subtract given expression by 1 so as to yield the correct end index for slicing
+                    var literal = new elm.Literal
+                    {
+                        value = "1",
+                        valueType = new System.Xml.XmlQualifiedName("{urn:hl7-org:elm-types:r1}Integer")
+                    };
 
-            var subtractExpr = OperatorBinding.Bind(CqlOperator.Subtract, ctx.RuntimeContextParameter, expression, literalOneExp);
+                    var literalOneExp = TranslateExpression(literal, ctx);
 
-            return subtractExpr;
+                    var subtractExpr = OperatorBinding.Bind(CqlOperator.Subtract, ctx.RuntimeContextParameter, expression, literalOneExp);
+
+                    return subtractExpr;
+                }
+                else
+                {
+                    return expression;
+                }
+            }
+            else
+            {
+                return expression;
+            }
         }
-
     }
-    
-
 }

--- a/Cql/Cql.Compiler/ExpressionBuilder.ListOperators.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.ListOperators.cs
@@ -60,9 +60,17 @@ namespace Hl7.Cql.Compiler
             var start = slice.startIndex == null || slice.startIndex is elm.Null
                 ? Expression.Constant(null, typeof(int?))
                 : TranslateExpression(slice.startIndex!, ctx);
-            var end = slice.endIndex == null || slice.endIndex is elm.Null
+            var endExpr = slice.endIndex == null || slice.endIndex is elm.Null
                 ? Expression.Constant(null, typeof(int?))
                 : TranslateExpression(slice.endIndex!, ctx);
+
+            Expression end = endExpr;
+
+            if (ctx.Parent != null && ctx.Parent is Hl7.Cql.Elm.FunctionDef parentElement && parentElement.name != null && parentElement.name.ToString() == "Take last item")
+            {
+                end = WrapWithAdditionalSubtract(endExpr, ctx);
+            }
+
             if (IsOrImplementsIEnumerableOfT(source.Type))
             {
                 return OperatorBinding.Bind(CqlOperator.Slice, ctx.RuntimeContextParameter, source, start, end);
@@ -70,5 +78,23 @@ namespace Hl7.Cql.Compiler
             throw new NotImplementedException();
         }
 
+        private Expression WrapWithAdditionalSubtract(Expression expression, ExpressionBuilderContext ctx)
+        {
+            //create new expression to Subtract given expression by 1 so as to yield the correct end index for slicing
+            var literal = new elm.Literal
+            {
+                value = "1",
+                valueType = new System.Xml.XmlQualifiedName("{urn:hl7-org:elm-types:r1}Integer")
+            };
+
+            var literalOneExp = TranslateExpression(literal, ctx);
+
+            var subtractExpr = OperatorBinding.Bind(CqlOperator.Subtract, ctx.RuntimeContextParameter, expression, literalOneExp);
+
+            return subtractExpr;
+        }
+
     }
+    
+
 }

--- a/Cql/Cql.Compiler/ExpressionBuilder.ListOperators.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.ListOperators.cs
@@ -76,7 +76,9 @@ namespace Hl7.Cql.Compiler
 
         private Expression WrapWithSubtractExpression(Expression expression, ExpressionBuilderContext ctx)
         {
-            if (ctx.Parent != null && ctx.Parent is Hl7.Cql.Elm.FunctionDef parentElement && parentElement.name != null)
+            Hl7.Cql.Elm.ExpressionDef? parentElement = ctx.Parent as Hl7.Cql.Elm.ExpressionDef;
+
+            if (parentElement != null && parentElement.name != null)
             {
                 // Check for annotation-tag with name == "operation" and value == "take-induced-slice"
                 var annotations = parentElement.annotation ?? Array.Empty<Hl7.Cql.Elm.Annotation>();


### PR DESCRIPTION
Added a wrapper to 
- check if source of Slice is originated from an elm Parent with elm annotation/tag @operation: take-induced-slice
- add a new Literal expression and wrap given expression with it, then add a Subtract operation binding
- added tests in ExpressionBuilderTest and PrimitiveTest for Slice operation and expression