### PR TITLE
Fix slice implementation

### DIFF
--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -19,6 +19,9 @@ using System.Linq.Expressions;
 using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
 using DateTimePrecision = Hl7.Cql.Iso8601.DateTimePrecision;
 using Expression = System.Linq.Expressions.Expression;
+using Description = Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute;
+using System.Xml.Linq;
+using Hl7.Fhir.Language.Debugging;
 
 namespace CoreTests
 {
@@ -3606,9 +3609,17 @@ namespace CoreTests
             Assert.IsFalse(meets ?? false);
         }
 
+        #region Slice tests
+
+        /* Refer http://cql.hl7.org/09-b-cqlreference.html for operation details on Skip, Tail and Take cql operators 
+         * These CQL operators uses Slice semantics from http://cql.hl7.org/04-logicalspecification.html#slice
+        */
+        
+        [TestCategory("SliceTests")]
         [TestMethod]
-        public void Slice_for_Skip2()
+        public void Skip2()
         {
+            //The Skip operator returns the elements in the list, skipping the first number elements. 
             //define "Skip2": Skip({ 1, 2, 3, 4, 5 }, 2) // { 3, 4, 5 }
             var rtx = GetNewContext();
             var inputList = new List<int> { 1, 2, 3, 4, 5 };
@@ -3618,9 +3629,11 @@ namespace CoreTests
             CollectionAssert.AreEqual(expectedList, slicedList.ToList());
         }
 
+        [TestCategory("SliceTests")]
         [TestMethod]
-        public void Slice_for_SkipNull()
+        public void SkipNull()
         {
+            //If the number of elements is null, the result is the entire list, no elements are skipped.
             //define "SkipNull": Skip({ 1, 3, 5 }, null) // { 1, 3, 5 }
             var rtx = GetNewContext();
             var inputList = new List<int> { 1, 3, 5 };
@@ -3630,9 +3643,11 @@ namespace CoreTests
             CollectionAssert.AreEqual(expectedList, slicedList.ToList());
         }
 
+        [TestCategory("SliceTests")]
         [TestMethod]
-        public void Slice_for_SkipEmpty()
+        public void SkipEmpty()
         {
+            //If the number of elements is less than zero, the result is an empty list.
             //define "SkipEmpty": Skip({ 1, 3, 5 }, -1) // { }
             var rtx = GetNewContext();
             var inputList = new List<int> { 1, 3, 5 };
@@ -3642,9 +3657,11 @@ namespace CoreTests
             CollectionAssert.AreEqual(expectedList, slicedList.ToList());
         }
 
+        [TestCategory("SliceTests")]
         [TestMethod]
-        public void Slice_for_SkipIsNull()
+        public void SkipIsNull()
         {
+            //If the source list is null, the result is null.
             //define "SkipIsNull": Skip(null, 2)
             var rtx = GetNewContext();
             var inputList = null as List<int>;
@@ -3653,9 +3670,11 @@ namespace CoreTests
             Assert.IsNull(slicedList);
         }
 
+        [TestCategory("SliceTests")]
         [TestMethod]
-        public void Slice_for_Tail234()
+        public void Tail234()
         {
+            //The Tail operator returns all but the first element from the given list. 
             //define "Tail234": Tail({ 1, 2, 3, 4 }) // { 2, 3, 4 }
             var rtx = GetNewContext();
             var inputList = new List<int> { 1, 2, 3, 4 };
@@ -3665,9 +3684,11 @@ namespace CoreTests
             CollectionAssert.AreEqual(expectedList, slicedList.ToList());
         }
 
+        [TestCategory("SliceTests")]
         [TestMethod]
-        public void Slice_for_TailEmpty()
+        public void TailEmpty()
         {
+            //If the list is empty, the result is empty.
             //define "TailEmpty": Tail({ }) // { }
             var rtx = GetNewContext();
             var inputList = new List<int> {  };
@@ -3677,9 +3698,11 @@ namespace CoreTests
             CollectionAssert.AreEqual(expectedList, slicedList.ToList());
         }
 
+        [TestCategory("SliceTests")]
         [TestMethod]
-        public void Slice_for_TailIsNull()
+        public void TailIsNull()
         {
+            //If the source list is null, the result is null.
             //define "TailIsNull": Tail(null)
             var rtx = GetNewContext();
             var inputList = null as List<int>;
@@ -3688,9 +3711,11 @@ namespace CoreTests
             Assert.IsNull(slicedList);
         }
 
+        [TestCategory("SliceTests")]
         [TestMethod]
-        public void Slice_for_Take2()
+        public void Take2()
         {
+            //The Take operator returns the first number elements from the given list.
             //define "Take2": Take({ 1, 2, 3, 4 }, 2) // { 1, 2 }
             var rtx = GetNewContext();
             var inputList = new List<int> { 1, 2, 3, 4 };
@@ -3700,9 +3725,11 @@ namespace CoreTests
             CollectionAssert.AreEqual(expectedList, slicedList.ToList());
         }
 
+        [TestCategory("SliceTests")]
         [TestMethod]
-        public void Slice_for_TakeTooMany()
+        public void TakeTooMany()
         {
+            //If the list has less than number elements, the result only contains the elements in the list.
             //define "TakeTooMany": Take({ 1, 2 }, 3) // { 1, 2 }
             var rtx = GetNewContext();
             var inputList = new List<int> { 1, 2 };
@@ -3712,9 +3739,11 @@ namespace CoreTests
             CollectionAssert.AreEqual(expectedList, slicedList.ToList());
         }
 
+        [TestCategory("SliceTests")]
         [TestMethod]
-        public void Slice_for_TakeEmpty()
+        public void TakeEmpty()
         {
+            //If number is null, or 0 or less, the result is an empty list.
             //define "TakeEmpty": Take({ 1, 2, 3, 4 }, null) // { }
             var rtx = GetNewContext();
             var inputList = new List<int> { 1, 2, 3, 4 };
@@ -3724,9 +3753,11 @@ namespace CoreTests
             CollectionAssert.AreEqual(expectedList, slicedList.ToList());
         }
 
+        [TestCategory("SliceTests")]
         [TestMethod]
-        public void Slice_for_TakeIsNull()
+        public void TakeIsNull()
         {
+            //If the source list is null, the result is null.
             //define "TakeIsNull": Take(null, 2)
             var rtx = GetNewContext();
             var inputList = null as List<int>;
@@ -3734,5 +3765,33 @@ namespace CoreTests
             var slicedList = rtx.Operators.Slice(inputList, 0, 2);
             Assert.IsNull(slicedList);
         }
+
+        [TestCategory("SliceTests")]
+        [TestMethod]
+        public void Slice_array_source()
+        {
+            //Testing array as a source for Slice operator
+            var rtx = GetNewContext();
+            var inputSource = new [] { 1, 2, 3, 4 };
+            var expectedList = new List<int> { 1, 2 };
+            var slicedList = rtx.Operators.Slice(inputSource, 0, 2);
+            Assert.IsNotNull(slicedList);
+            CollectionAssert.AreEqual(expectedList, slicedList.ToList());
+        }
+
+        [TestCategory("SliceTests")]
+        [TestMethod]
+        public void Slice_linkedList_source()
+        {
+            // Testing LinkedList as a source for Slice operator
+            var rtx = GetNewContext();
+            var inputSource = new LinkedList<int>(new[] { 1, 2, 3, 4 });
+            var expectedList = new List<int> { 1, 2 };
+            var slicedList = rtx.Operators.Slice(inputSource, 0, 2);
+            Assert.IsNotNull(slicedList);
+            CollectionAssert.AreEqual(expectedList, slicedList.ToList());
+        }
+
+        #endregion
     }
 }

--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -1,6 +1,7 @@
 ﻿using Hl7.Cql.Abstractions;
 using Hl7.Cql.CodeGeneration.NET;
 using Hl7.Cql.Compiler;
+using Hl7.Cql.Elm;
 using Hl7.Cql.Fhir;
 using Hl7.Cql.Iso8601;
 using Hl7.Cql.Operators;
@@ -15,6 +16,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
+using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
 using DateTimePrecision = Hl7.Cql.Iso8601.DateTimePrecision;
 using Expression = System.Linq.Expressions.Expression;
 
@@ -3602,6 +3604,135 @@ namespace CoreTests
                 null);
             Assert.IsNotNull(meets);
             Assert.IsFalse(meets ?? false);
+        }
+
+        [TestMethod]
+        public void Slice_for_Skip2()
+        {
+            //define "Skip2": Skip({ 1, 2, 3, 4, 5 }, 2) // { 3, 4, 5 }
+            var rtx = GetNewContext();
+            var inputList = new List<int> { 1, 2, 3, 4, 5 };
+            var expectedList = new List<int> { 3, 4, 5 };
+            var slicedList = rtx.Operators.Slice(inputList, 2, null);
+            Assert.IsNotNull(slicedList);
+            CollectionAssert.AreEqual(expectedList, slicedList.ToList());
+        }
+
+        [TestMethod]
+        public void Slice_for_SkipNull()
+        {
+            //define "SkipNull": Skip({ 1, 3, 5 }, null) // { 1, 3, 5 }
+            var rtx = GetNewContext();
+            var inputList = new List<int> { 1, 3, 5 };
+            var expectedList = new List<int> { 1, 3, 5 };
+            var slicedList = rtx.Operators.Slice(inputList, null, null);
+            Assert.IsNotNull(slicedList);
+            CollectionAssert.AreEqual(expectedList, slicedList.ToList());
+        }
+
+        [TestMethod]
+        public void Slice_for_SkipEmpty()
+        {
+            //define "SkipEmpty": Skip({ 1, 3, 5 }, -1) // { }
+            var rtx = GetNewContext();
+            var inputList = new List<int> { 1, 3, 5 };
+            var expectedList = new List<int> {};
+            var slicedList = rtx.Operators.Slice(inputList, -1, null);
+            Assert.IsNotNull(slicedList);
+            CollectionAssert.AreEqual(expectedList, slicedList.ToList());
+        }
+
+        [TestMethod]
+        public void Slice_for_SkipIsNull()
+        {
+            //define "SkipIsNull": Skip(null, 2)
+            var rtx = GetNewContext();
+            var inputList = null as List<int>;
+            var expectedList = null as List<int>;
+            var slicedList = rtx.Operators.Slice(inputList, 2, null);
+            Assert.IsNull(slicedList);
+        }
+
+        [TestMethod]
+        public void Slice_for_Tail234()
+        {
+            //define "Tail234": Tail({ 1, 2, 3, 4 }) // { 2, 3, 4 }
+            var rtx = GetNewContext();
+            var inputList = new List<int> { 1, 2, 3, 4 };
+            var expectedList = new List<int> { 2, 3, 4 };
+            var slicedList = rtx.Operators.Slice(inputList, 1, null);
+            Assert.IsNotNull(slicedList);
+            CollectionAssert.AreEqual(expectedList, slicedList.ToList());
+        }
+
+        [TestMethod]
+        public void Slice_for_TailEmpty()
+        {
+            //define "TailEmpty": Tail({ }) // { }
+            var rtx = GetNewContext();
+            var inputList = new List<int> {  };
+            var expectedList = new List<int> { };
+            var slicedList = rtx.Operators.Slice(inputList, 1, null);
+            Assert.IsNotNull(slicedList);
+            CollectionAssert.AreEqual(expectedList, slicedList.ToList());
+        }
+
+        [TestMethod]
+        public void Slice_for_TailIsNull()
+        {
+            //define "TailIsNull": Tail(null)
+            var rtx = GetNewContext();
+            var inputList = null as List<int>;
+            var expectedList = null as List<int>;
+            var slicedList = rtx.Operators.Slice(inputList, 1, null);
+            Assert.IsNull(slicedList);
+        }
+
+        [TestMethod]
+        public void Slice_for_Take2()
+        {
+            //define "Take2": Take({ 1, 2, 3, 4 }, 2) // { 1, 2 }
+            var rtx = GetNewContext();
+            var inputList = new List<int> { 1, 2, 3, 4 };
+            var expectedList = new List<int> { 1, 2 };
+            var slicedList = rtx.Operators.Slice(inputList, 0, 2);
+            Assert.IsNotNull(slicedList);
+            CollectionAssert.AreEqual(expectedList, slicedList.ToList());
+        }
+
+        [TestMethod]
+        public void Slice_for_TakeTooMany()
+        {
+            //define "TakeTooMany": Take({ 1, 2 }, 3) // { 1, 2 }
+            var rtx = GetNewContext();
+            var inputList = new List<int> { 1, 2 };
+            var expectedList = new List<int> { 1, 2 };
+            var slicedList = rtx.Operators.Slice(inputList, 0, 3);
+            Assert.IsNotNull(slicedList);
+            CollectionAssert.AreEqual(expectedList, slicedList.ToList());
+        }
+
+        [TestMethod]
+        public void Slice_for_TakeEmpty()
+        {
+            //define "TakeEmpty": Take({ 1, 2, 3, 4 }, null) // { }
+            var rtx = GetNewContext();
+            var inputList = new List<int> { 1, 2, 3, 4 };
+            var expectedList = new List<int> { };
+            var slicedList = rtx.Operators.Slice(inputList, 0, 0);
+            Assert.IsNotNull(slicedList);
+            CollectionAssert.AreEqual(expectedList, slicedList.ToList());
+        }
+
+        [TestMethod]
+        public void Slice_for_TakeIsNull()
+        {
+            //define "TakeIsNull": Take(null, 2)
+            var rtx = GetNewContext();
+            var inputList = null as List<int>;
+            var expectedList = null as List<int>;
+            var slicedList = rtx.Operators.Slice(inputList, 0, 2);
+            Assert.IsNull(slicedList);
         }
     }
 }

--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -1,7 +1,6 @@
 ﻿using Hl7.Cql.Abstractions;
 using Hl7.Cql.CodeGeneration.NET;
 using Hl7.Cql.Compiler;
-using Hl7.Cql.Elm;
 using Hl7.Cql.Fhir;
 using Hl7.Cql.Iso8601;
 using Hl7.Cql.Operators;
@@ -16,7 +15,6 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
-using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
 using DateTimePrecision = Hl7.Cql.Iso8601.DateTimePrecision;
 using Expression = System.Linq.Expressions.Expression;
 

--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -19,9 +19,6 @@ using System.Linq.Expressions;
 using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
 using DateTimePrecision = Hl7.Cql.Iso8601.DateTimePrecision;
 using Expression = System.Linq.Expressions.Expression;
-using Description = Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute;
-using System.Xml.Linq;
-using Hl7.Fhir.Language.Debugging;
 
 namespace CoreTests
 {

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -14,7 +14,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Xml.Linq;
 
 namespace Hl7.Cql.Runtime
 {

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Xml.Linq;
 
 namespace Hl7.Cql.Runtime
 {
@@ -1101,28 +1102,37 @@ namespace Hl7.Cql.Runtime
 
         public IEnumerable<T>? Slice<T>(IEnumerable<T>? source, int? startIndex, int? endIndex)
         {
+            //If the source list is null, the result is null.
             if (source == null)
                 return null;
-            if ((startIndex == null && endIndex == null) || !source.Any())
-            {
+
+            //define "TailEmpty": Tail({ }) // { }
+            if (!source.Any())
                 return Enumerable.Empty<T>();
-            }
-            var si = startIndex ?? 0;
-            if (source is List<T> list)
+
+            //define "SkipNull": Skip({ 1, 3, 5 }, null) // { 1, 3, 5 }
+            if (startIndex == null && endIndex == null)
+                return source;
+
+            //If the number of elements is less than zero, the result is an empty list.
+            //define "SkipEmpty": Skip({ 1, 3, 5 }, -1) // { }
+            if (startIndex < 0)
+                return Enumerable.Empty<T>();
+
+            //If number is null, or 0 or less, the result is an empty list.
+            //define "TakeEmpty": Take({ 1, 2, 3, 4 }, null) // { }
+            if (endIndex <= 0)
+                return Enumerable.Empty<T>();
+
+            //Skip and Tail operations where the endIndex is always null
+            if (endIndex == null)
             {
-                var lcm1 = list.Count - 1;
-                var ei = Math.Min(endIndex ?? lcm1, lcm1);
-                var count = ei - si + 1;
-                var slice = list.GetRange(si, count);
-                return slice;
+                return source.Skip(startIndex ?? 0).ToList();
             }
+            //Take operation
             else
             {
-                var skip = source.Skip(si);
-                var result = new List<T>();
-                foreach (var item in skip.Take(endIndex ?? int.MaxValue))
-                    result.Add(item);
-                return result;
+                return source.Skip(startIndex ?? 0).Take((endIndex ?? 0) - (startIndex ?? 0)).ToList();
             }
         }
 

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -1102,34 +1102,22 @@ namespace Hl7.Cql.Runtime
 
         public IEnumerable<T>? Slice<T>(IEnumerable<T>? source, int? startIndex, int? endIndex)
         {
-            //If the source list is null, the result is null.
             if (source == null)
                 return null;
 
-            //define "TailEmpty": Tail({ }) // { }
             if (!source.Any())
                 return Enumerable.Empty<T>();
 
-            //define "SkipNull": Skip({ 1, 3, 5 }, null) // { 1, 3, 5 }
             if (startIndex == null && endIndex == null)
                 return source;
 
-            //If the number of elements is less than zero, the result is an empty list.
-            //define "SkipEmpty": Skip({ 1, 3, 5 }, -1) // { }
-            if (startIndex < 0)
+            if (startIndex < 0 || endIndex <= 0)
                 return Enumerable.Empty<T>();
 
-            //If number is null, or 0 or less, the result is an empty list.
-            //define "TakeEmpty": Take({ 1, 2, 3, 4 }, null) // { }
-            if (endIndex <= 0)
-                return Enumerable.Empty<T>();
-
-            //Skip and Tail operations where the endIndex is always null
             if (endIndex == null)
             {
                 return source.Skip(startIndex ?? 0).ToList();
             }
-            //Take operation
             else
             {
                 return source.Skip(startIndex ?? 0).Take((endIndex ?? 0) - (startIndex ?? 0)).ToList();


### PR DESCRIPTION
**Current State:**
 The Slice method in the engine does not slice per expected Slice definition (http://cql.hl7.org/04-logicalspecification.html#slice) when the input source is of type List.

Also, it does not handle multiple different cases defined in Skip, Tail and Take operators as expected (http://cql.hl7.org/09-b-cqlreference.html)

Fixes:

- Fixed the Slice method in the engine to handle all valid cases defined for Skip Tail and Take that follows Slice semantics.
- Added unit tests to ensure everything is aligned per expected operations for Slice.