### PR TITLE
Per https://statics.teams.cdn.office.net/evergreen-assets/safelinks/2…

### DIFF
--- a/Cql/Cql.Operators/CqlOperators.IntervalOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.IntervalOperators.cs
@@ -1971,10 +1971,8 @@ namespace Hl7.Cql.Runtime
 
         public bool? IntervalProperlyIncludedInInterval<T>(CqlInterval<T>? left, CqlInterval<T>? right, string precision)
         {
-            if (left == null)
+            if (left == null || right == null)
                 return null;
-            if (right == null)
-                return false;
 
             var min = Minimum<T>()!;
 


### PR DESCRIPTION
per cql specs https://cql.hl7.org/2020May/09-b-cqlreference.html#properly-included-in where it says if either interval is null then return null, our current engine is incorrect as it returns false, instead of null
```
public bool? IntervalProperlyIncludedInInterval<T>(CqlInterval<T>? left, CqlInterval<T>? right, string precision)
{
    if (left == null)
        return null;
    if (right == null)
        return **false**;
```
 Impacted measure PCE tested; Other measures with reference to properly included in but no direct impact tested as well