### PR TITLE
Fix implementation of Duration Between days

### DIFF
--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -3790,12 +3790,36 @@ namespace CoreTests
         #endregion
 
         [TestMethod]
-        public void DurationBetweenDaysWithSameTime()
+        public void DurationBetweenDifferentDaysWithSameTime()
         {
             var rtx = GetNewContext();
             var startDate = new CqlDate(2025, 1, 1);
             var endDate = new CqlDate(2025, 1, 10);
             int expected = 10;
+            var actual = rtx.Operators.DurationBetween(startDate, endDate, "day");
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void DurationBetweenSameDay()
+        {
+            var rtx = GetNewContext();
+            var startDate = new CqlDate(2025, 1, 1);
+            var endDate = new CqlDate(2025, 1, 1);
+            int expected = 0;
+            var actual = rtx.Operators.DurationBetween(startDate, endDate, "day");
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void DurationBetweenDifferentDaysInvalid()
+        {
+            var rtx = GetNewContext();
+            var startDate = new CqlDate(2025, 1, 10);
+            var endDate = new CqlDate(2025, 1, 1);
+            int expected = -9;
             var actual = rtx.Operators.DurationBetween(startDate, endDate, "day");
             Assert.IsNotNull(actual);
             Assert.AreEqual(expected, actual);

--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -3790,7 +3790,7 @@ namespace CoreTests
         #endregion
 
         [TestMethod]
-        public void DurationBetweenDifferentDaysWithSameTime()
+        public void DurationBetweenDifferentDays()
         {
             var rtx = GetNewContext();
             var startDate = new CqlDate(2025, 1, 1);
@@ -3807,14 +3807,14 @@ namespace CoreTests
             var rtx = GetNewContext();
             var startDate = new CqlDate(2025, 1, 1);
             var endDate = new CqlDate(2025, 1, 1);
-            int expected = 0;
+            int expected = 1;
             var actual = rtx.Operators.DurationBetween(startDate, endDate, "day");
             Assert.IsNotNull(actual);
             Assert.AreEqual(expected, actual);
         }
 
         [TestMethod]
-        public void DurationBetweenDifferentDaysInvalid()
+        public void DurationBetweenDifferentDaysNegative()
         {
             var rtx = GetNewContext();
             var startDate = new CqlDate(2025, 1, 10);

--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -3788,5 +3788,18 @@ namespace CoreTests
         }
 
         #endregion
+
+        [TestMethod]
+        public void DurationBetweenDaysWithSameTime()
+        {
+            var rtx = GetNewContext();
+            var startDate = new CqlDate(2025, 1, 1);
+            var endDate = new CqlDate(2025, 1, 10);
+            int expected = 10;
+            var actual = rtx.Operators.DurationBetween(startDate, endDate, "day");
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(expected, actual);
+        }
+
     }
 }

--- a/Cql/Cql.Primitives/CqlDateTimeMath.cs
+++ b/Cql/Cql.Primitives/CqlDateTimeMath.cs
@@ -204,8 +204,13 @@ namespace Hl7.Cql.Primitives
                     return monthDiff;
                 case "week": 
                     return (int)(secondDto.Subtract(firstDto).TotalDays / DaysPerWeekDouble);
-                case "day": 
-                    return (int)secondDto.Subtract(firstDto).TotalDays;
+                case "day":
+                    var days = (int)secondDto.Subtract(firstDto).TotalDays;
+                    // Per https://cql.hl7.org/15-h-timeintervalcalculations.html,
+                    // If the time portions are equal, include the end date as a full day
+                    if (secondDto.TimeOfDay >= firstDto.TimeOfDay)
+                        days += 1;
+                    return days;
                 case "hour": 
                     return (int)secondDto.Subtract(firstDto).TotalHours;
                 case "minute": 

--- a/Cql/Cql.Primitives/CqlDateTimeMath.cs
+++ b/Cql/Cql.Primitives/CqlDateTimeMath.cs
@@ -206,8 +206,7 @@ namespace Hl7.Cql.Primitives
                     return (int)(secondDto.Subtract(firstDto).TotalDays / DaysPerWeekDouble);
                 case "day":
                     var days = (int)secondDto.Subtract(firstDto).TotalDays;
-                    // Per https://cql.hl7.org/15-h-timeintervalcalculations.html,
-                    // If the greater date's time of the day is greater or equal to smaller date, include the end date as a full day
+                    // Per https://cql.hl7.org/15-h-timeintervalcalculations.html
                     if ((secondDto.Date >= firstDto.Date) && (secondDto.TimeOfDay >= firstDto.TimeOfDay))
                         days += 1;
                     return days;

--- a/Cql/Cql.Primitives/CqlDateTimeMath.cs
+++ b/Cql/Cql.Primitives/CqlDateTimeMath.cs
@@ -208,7 +208,7 @@ namespace Hl7.Cql.Primitives
                     var days = (int)secondDto.Subtract(firstDto).TotalDays;
                     // Per https://cql.hl7.org/15-h-timeintervalcalculations.html,
                     // If the greater date's time of the day is greater or equal to smaller date, include the end date as a full day
-                    if ((secondDto.Date > firstDto.Date) && (secondDto.TimeOfDay >= firstDto.TimeOfDay))
+                    if ((secondDto.Date >= firstDto.Date) && (secondDto.TimeOfDay >= firstDto.TimeOfDay))
                         days += 1;
                     return days;
                 case "hour": 

--- a/Cql/Cql.Primitives/CqlDateTimeMath.cs
+++ b/Cql/Cql.Primitives/CqlDateTimeMath.cs
@@ -207,8 +207,8 @@ namespace Hl7.Cql.Primitives
                 case "day":
                     var days = (int)secondDto.Subtract(firstDto).TotalDays;
                     // Per https://cql.hl7.org/15-h-timeintervalcalculations.html,
-                    // If the time portions are equal, include the end date as a full day
-                    if (secondDto.TimeOfDay >= firstDto.TimeOfDay)
+                    // If the greater date's time of the day is greater or equal to smaller date, include the end date as a full day
+                    if ((secondDto.Date > firstDto.Date) && (secondDto.TimeOfDay >= firstDto.TimeOfDay))
                         days += 1;
                     return days;
                 case "hour": 


### PR DESCRIPTION
Per Cql Specs, https://cql.hl7.org/15-h-timeintervalcalculations.html#calculating-duration-in-days

When evaluating duration between two dates, we need to evaluate if the second date (recent or same date) is of same or greater time of the day than the first. If the times are same or the second date time is greater than the first, we need to include the second date as well while evaluating the duration between the input days.

Currently, for a cql operation like duration in days between "2025-01-01" and "2025-01-10", 
the engine's DurationBetween() implementation returns 9 days since it does not include the end date.

However, per the spec, it should have returned 10 days, since the input date are without time so it translates to same time of the day in its date time offset format.

