### PR TITLE
Fix Sum operation on Quantity types

### DIFF
--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -3788,5 +3788,17 @@ namespace CoreTests
         }
 
         #endregion
+
+        [TestMethod]
+        public void SumQuantity()
+        {
+            var rtx = GetNewContext();
+            var inputSource = new List<CqlQuantity?> { new CqlQuantity(value: 1, unit: "day"), new CqlQuantity(value: 5, unit: "day") };
+            CqlQuantity expectedValue = new CqlQuantity(value: 6, unit: "day");
+            var computedValue = rtx.Operators.Sum(inputSource);
+
+            Assert.AreEqual(expectedValue.value, computedValue.value);
+            Assert.AreEqual(expectedValue.unit, computedValue.unit);
+        }
     }
 }

--- a/Cql/Cql.Operators/CqlOperators.AggregateFunctions.cs
+++ b/Cql/Cql.Operators/CqlOperators.AggregateFunctions.cs
@@ -671,16 +671,16 @@ namespace Hl7.Cql.Runtime
                 .ToArray();
             if (nonNull.Length == 0)
                 return null;
-            decimal? product = 1;
+            decimal? sum = 0;
             string? unit = null;
             foreach (var v in nonNull)
             {
                 unit ??= (v!.unit ?? "1");
                 if (unit != v!.unit)
                     throw new NotSupportedException("Unlike units are not supported.");
-                product *= v.value!.Value;
+                sum += v.value!.Value;
             }
-            return new CqlQuantity(product, unit ?? "1");
+            return new CqlQuantity(sum, unit ?? "1");
         }
 
         #endregion


### PR DESCRIPTION
Current sdk implementation is incorrect as it does multiplication of values from provided input quantities, instead of summing them up.

Below provides the issue versus potential fix (fix will have sum=0 defaulted instead of sum=1)

<img width="1884" height="356" alt="hdo_sdk_issue" src="https://github.com/user-attachments/assets/5ee972fe-4212-4774-8d0a-3a9fb4a32a3f" />



